### PR TITLE
Implement atomic ID generation with transactional sequences

### DIFF
--- a/app.py
+++ b/app.py
@@ -113,6 +113,8 @@ def create_credit_line():
     try:
         cl_id = db.create_credit_line(conn, data)
         return jsonify({"ok": True, "id": cl_id})
+    except db.WriteBusyError:
+        return jsonify({"ok": False, "error": "Database is busy. Please retry."}), 503
     finally:
         conn.close()
 
@@ -172,6 +174,8 @@ def create_advance():
     try:
         fv_id = db.create_advance(conn, data)
         return jsonify({"ok": True, "id": fv_id})
+    except db.WriteBusyError:
+        return jsonify({"ok": False, "error": "Database is busy. Please retry."}), 503
     finally:
         conn.close()
 

--- a/draft-08-atomic-id-generation.md
+++ b/draft-08-atomic-id-generation.md
@@ -1,0 +1,55 @@
+# Draft 08: Atomic ID Generation
+
+## Goal
+Remove race conditions in `CL` and `FV` ID creation so concurrent requests cannot generate duplicate IDs.
+
+## Current Risk
+- Current flow reads max ID, increments in app code, then inserts.
+- Two simultaneous requests can calculate the same next ID and one fails.
+- A failed insert can surface as a user-facing server error.
+
+## Scope
+- `credit_lines.id` generation (`CL001`, `CL002`, ...)
+- `fixed_advances.id` generation (`FV0001`, `FV0002`, ...)
+- Related create APIs in Flask.
+
+## Recommended Approach
+1. Add sequence tables:
+- `id_sequences(name TEXT PRIMARY KEY, last_value INTEGER NOT NULL)`
+- Seed rows: `('credit_lines', <current max>)`, `('fixed_advances', <current max>)`
+
+2. Generate IDs inside a single DB transaction:
+- `BEGIN IMMEDIATE`
+- `UPDATE id_sequences SET last_value = last_value + 1 WHERE name = ?`
+- `SELECT last_value FROM id_sequences WHERE name = ?`
+- Build formatted ID (`CL%03d`, `FV%04d`)
+- Insert target row
+- `COMMIT`
+
+3. Handle collisions defensively:
+- Keep a retry loop (small bounded retries) around transaction for `SQLITE_BUSY`.
+- Return clean API errors if retry budget is exceeded.
+
+## Migration Plan
+1. Add migration creating `id_sequences`.
+2. Backfill sequence values from existing data:
+- `credit_lines`: max numeric part of `id` or 0
+- `fixed_advances`: max numeric part of `id` or 0
+3. Keep existing IDs unchanged.
+4. Deploy migration before app logic switch.
+
+## Test Plan
+1. Unit test ID formatting boundaries (`CL009` -> `CL010`, `FV0999` -> `FV1000`).
+2. Integration test create endpoints return unique IDs sequentially.
+3. Concurrency test (parallel creates) verifies no duplicates and no unhandled 500s.
+4. Migration test for empty DB and populated DB.
+
+## Acceptance Criteria
+- No duplicate `id` failures during parallel create tests.
+- Existing records remain intact.
+- ID format remains exactly as today.
+- Create endpoints return stable success/error responses under load.
+
+## Rollout / Fallback
+- Rollout as a single migration + app release.
+- Fallback: app can continue with existing tables; migration is additive and low risk.

--- a/tests/test_atomic_id_generation.py
+++ b/tests/test_atomic_id_generation.py
@@ -1,0 +1,164 @@
+import os
+import tempfile
+import threading
+import unittest
+
+import db
+
+
+class AtomicIdGenerationTests(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.db_path = os.path.join(self.tmpdir.name, "test.db")
+        self.orig_db_path = db.DB_PATH
+        db.DB_PATH = self.db_path
+        db.init_db()
+
+        conn = db.get_db()
+        try:
+            conn.execute(
+                "INSERT INTO banks (bank_key, bank_name) VALUES (?, ?)",
+                ("B001", "Bank 1"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def tearDown(self):
+        db.DB_PATH = self.orig_db_path
+        self.tmpdir.cleanup()
+
+    def _create_credit_line(self, idx=1):
+        conn = db.get_db()
+        try:
+            return db.create_credit_line(
+                conn,
+                {
+                    "bank_key": "B001",
+                    "description": f"Facility {idx}",
+                    "currency": "CHF",
+                    "amount": 100_000_000 + idx,
+                    "committed": "Yes",
+                    "start_date": "2026-01-01",
+                    "end_date": None,
+                    "note": None,
+                },
+            )
+        finally:
+            conn.close()
+
+    def test_credit_line_id_boundary_format(self):
+        conn = db.get_db()
+        try:
+            conn.execute(
+                "UPDATE id_sequences SET last_value = ? WHERE name = 'credit_lines'",
+                (9,),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        cl_id = self._create_credit_line(10)
+        self.assertEqual(cl_id, "CL010")
+
+    def test_advance_id_boundary_format(self):
+        cl_id = self._create_credit_line(1)
+        conn = db.get_db()
+        try:
+            conn.execute(
+                "UPDATE id_sequences SET last_value = ? WHERE name = 'fixed_advances'",
+                (999,),
+            )
+            conn.commit()
+            fv_id = db.create_advance(
+                conn,
+                {
+                    "bank": "Bank 1",
+                    "credit_line_id": cl_id,
+                    "start_date": "2026-01-10",
+                    "end_date": "2026-02-10",
+                    "continuation_date": "2026-02-05",
+                    "currency": "CHF",
+                    "amount_original": 10_000_000,
+                    "interest_amount": 10_000.0,
+                },
+            )
+        finally:
+            conn.close()
+
+        self.assertEqual(fv_id, "FV1000")
+
+    def test_parallel_credit_line_creates_are_unique(self):
+        worker_count = 8
+        barrier = threading.Barrier(worker_count)
+        ids = []
+        errors = []
+        lock = threading.Lock()
+
+        def worker(i):
+            try:
+                barrier.wait(timeout=5)
+                cl_id = self._create_credit_line(i)
+                with lock:
+                    ids.append(cl_id)
+            except Exception as exc:
+                with lock:
+                    errors.append(exc)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(worker_count)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        self.assertFalse(errors, f"Unexpected worker errors: {errors}")
+        self.assertEqual(len(ids), worker_count)
+        self.assertEqual(len(set(ids)), worker_count)
+
+    def test_parallel_advance_creates_are_unique(self):
+        worker_count = 8
+        barrier = threading.Barrier(worker_count)
+        ids = []
+        errors = []
+        lock = threading.Lock()
+        cl_id = self._create_credit_line(1)
+
+        def worker(i):
+            try:
+                barrier.wait(timeout=5)
+                conn = db.get_db()
+                try:
+                    fv_id = db.create_advance(
+                        conn,
+                        {
+                            "bank": "Bank 1",
+                            "credit_line_id": cl_id,
+                            "start_date": "2026-01-10",
+                            "end_date": "2026-02-10",
+                            "continuation_date": "2026-02-05",
+                            "currency": "CHF",
+                            "amount_original": 1_000_000 + i,
+                            "interest_amount": 1_000.0 + i,
+                        },
+                    )
+                finally:
+                    conn.close()
+                with lock:
+                    ids.append(fv_id)
+            except Exception as exc:
+                with lock:
+                    errors.append(exc)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(worker_count)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        self.assertFalse(errors, f"Unexpected worker errors: {errors}")
+        self.assertEqual(len(ids), worker_count)
+        self.assertEqual(len(set(ids)), worker_count)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
This PR removes race conditions in `CL`/`FV` ID creation under concurrent requests by moving ID allocation to a transactional sequence model in SQLite.

## What Changed
- Added `id_sequences` table and initialization/backfill migration in `/Users/denitsa/Library/Mobile Documents/iCloud~md~obsidian/Documents/Obsidian Vault/TenorDash/db.py`.
- Added transactional write wrapper using `BEGIN IMMEDIATE` with bounded retry for lock contention.
- Updated `create_credit_line` and `create_advance` to allocate IDs atomically from sequences.
- Kept ID formats unchanged (`CL%03d`, `FV%04d`).
- Added `WriteBusyError` handling in `/Users/denitsa/Library/Mobile Documents/iCloud~md~obsidian/Documents/Obsidian Vault/TenorDash/app.py` create endpoints to return clean `503` responses when DB stays locked.
- Added tests in `/Users/denitsa/Library/Mobile Documents/iCloud~md~obsidian/Documents/Obsidian Vault/TenorDash/tests/test_atomic_id_generation.py`:
  - ID boundary formatting (`CL010`, `FV1000`)
  - Parallel create uniqueness for credit lines and advances
- Included implementation draft doc: `/Users/denitsa/Library/Mobile Documents/iCloud~md~obsidian/Documents/Obsidian Vault/TenorDash/draft-08-atomic-id-generation.md`

## Why
The previous max+1 ID generation was non-atomic and could produce duplicate IDs when requests arrived at the same time.

## Validation
- Ran: `python3 -m unittest discover -s tests -v`
- Result: `4 passed`

## Risk / Compatibility
- Migration is additive (`id_sequences` only).
- Existing records are preserved.
- API behavior change: create endpoints can now return `503` with a clear retry message during prolonged lock contention.

## Checklist
- [x] Implemented atomic ID allocation for `credit_lines`
- [x] Implemented atomic ID allocation for `fixed_advances`
- [x] Added sequence init/backfill migration
- [x] Preserved existing ID formats
- [x] Added lock-retry handling
- [x] Added clean API error response on write contention
- [x] Added concurrency and boundary tests
- [x] Ran tests successfully

## Branch / Commit
- Branch: `codex/dev-atomic-id-generation`
- Commit: `fcdeaed`