### PR TITLE
Enforce End Date > Start Date for advances server-side

### DIFF
--- a/app.py
+++ b/app.py
@@ -40,7 +40,7 @@ def validate_advance_date_order(data):
     try:
         start = date.fromisoformat(data["start_date"])
         end = date.fromisoformat(data["end_date"])
-    except (TypeError, ValueError):
+    except (KeyError, TypeError, ValueError):
         return jsonify({"ok": False, "error": "start_date and end_date must be valid ISO dates"}), 400
 
     if end <= start:

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -199,6 +199,7 @@ class ApiContractTests(unittest.TestCase):
 
         res = self.client.post("/advances", json=payload)
         self.assertEqual(res.status_code, 400)
+        self.assertIn("end_date must be later than start_date", res.get_json()["error"])
 
     def test_advance_update_invalid_date_order_fails(self):
         cl_id = self._create_credit_line()
@@ -211,6 +212,16 @@ class ApiContractTests(unittest.TestCase):
         payload["end_date"] = "2026-02-28"
         update_res = self.client.put(f"/advances/{fv_id}", json=payload)
         self.assertEqual(update_res.status_code, 400)
+        self.assertIn("end_date must be later than start_date", update_res.get_json()["error"])
+
+    def test_advance_create_malformed_date_fails(self):
+        cl_id = self._create_credit_line()
+        payload = self._advance_payload(cl_id)
+        payload["start_date"] = "bad-date"
+
+        res = self.client.post("/advances", json=payload)
+        self.assertEqual(res.status_code, 400)
+        self.assertIn("must be valid ISO dates", res.get_json()["error"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
What changed:

app.py
Added validate_advance_date_order(data) helper.
Enforced server-side rule for both create and update:
end_date must be strictly later than start_date.
Returns 400 with clear message if invalid or malformed.
test_api_contract.py
Added:
test_advance_create_invalid_date_order_fails
test_advance_update_invalid_date_order_fails
Validation run:

python3 -m py_compile $(git ls-files '*.py') passed
python3 -m unittest discover -s tests -v passed (API tests are skipped in this local runtime when Flask isn’t installed, but they run in CI)