### PR TITLE
Add view-only panel mode on row click

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -169,6 +169,13 @@ async function saveSettings(e) {
   location.reload();
 }
 
+// Format ISO date string as "Mon DD, YYYY" for view panels.
+function formatDate(iso) {
+  if (!iso) return '\u2014';
+  const d = new Date(iso + 'T00:00:00');
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
 // Shared locale-aware number parsing/formatting helpers for forms.
 window.TDNumber = (function() {
   const decSep = (1.1).toLocaleString().charAt(1);

--- a/static/style.css
+++ b/static/style.css
@@ -946,3 +946,71 @@ tr[data-archived="true"]:hover td { opacity: 0.75; }
 }
 .folder-status { font-size: 11px; color: var(--text-light); }
 .btn-sm { padding: 5px 12px; font-size: 12px; }
+
+/* ── Panel View Mode ── */
+
+.panel-view .detail-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0 12px;
+}
+
+.panel-view .detail-item {
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.panel-view .detail-item.full-width {
+  grid-column: 1 / -1;
+}
+
+.panel-view .detail-label {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  margin-bottom: 4px;
+}
+
+.panel-view .detail-value {
+  font-size: 13px;
+  color: var(--text);
+}
+
+.panel-view .detail-value.mono {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 12px;
+}
+
+.panel-view .detail-value .badge {
+  vertical-align: middle;
+}
+
+.panel-view .detail-calc {
+  background: var(--bg);
+  border-radius: 6px;
+  padding: 14px 16px;
+  margin: 16px 0;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.panel-view .detail-calc .calc-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  margin-bottom: 2px;
+}
+
+.panel-view .detail-calc .calc-value {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+/* Clickable table rows */
+.data-table tbody tr[data-id] { cursor: pointer; }

--- a/templates/advances.html
+++ b/templates/advances.html
@@ -44,7 +44,7 @@
     </thead>
     <tbody>
       {% for adv in advances %}
-      <tr data-currency="{{ adv.currency }}" data-active="{{ 'true' if adv.active else 'false' }}">
+      <tr data-id="{{ adv.id }}" data-currency="{{ adv.currency }}" data-active="{{ 'true' if adv.active else 'false' }}">
         <td class="mono text-muted">{{ adv.id }}</td>
         <td>{{ adv.bank }}</td>
         <td class="text-muted">{{ adv.credit_line_id }}</td>
@@ -80,10 +80,71 @@
 <div class="panel-overlay" id="adv-panel">
   <div class="slide-panel">
     <h3>
-      <span id="adv-form-title">New Fixed Advance</span>
+      <span id="adv-panel-title">New Fixed Advance</span>
       <button class="panel-close" onclick="closeAdvForm()">&times;</button>
     </h3>
-    <form id="adv-form" onsubmit="saveAdv(event)">
+
+    <!-- View mode -->
+    <div id="adv-view" class="panel-view" style="display:none">
+      <div class="detail-grid">
+        <div class="detail-item">
+          <div class="detail-label">Bank</div>
+          <div class="detail-value" id="adv-view-bank"></div>
+        </div>
+        <div class="detail-item">
+          <div class="detail-label">Credit Line</div>
+          <div class="detail-value" id="adv-view-cl"></div>
+        </div>
+        <div class="detail-item">
+          <div class="detail-label">Currency</div>
+          <div class="detail-value" id="adv-view-currency"></div>
+        </div>
+        <div class="detail-item">
+          <div class="detail-label">Amount</div>
+          <div class="detail-value mono" id="adv-view-amount"></div>
+        </div>
+        <div class="detail-item">
+          <div class="detail-label">Interest Amount</div>
+          <div class="detail-value mono" id="adv-view-interest"></div>
+        </div>
+        <div class="detail-item">
+          <div class="detail-label">Status</div>
+          <div class="detail-value" id="adv-view-status"></div>
+        </div>
+        <div class="detail-item">
+          <div class="detail-label">Start Date</div>
+          <div class="detail-value" id="adv-view-start"></div>
+        </div>
+        <div class="detail-item">
+          <div class="detail-label">End Date</div>
+          <div class="detail-value" id="adv-view-end"></div>
+        </div>
+        <div class="detail-item full-width">
+          <div class="detail-label">Continuation Date</div>
+          <div class="detail-value" id="adv-view-cont"></div>
+        </div>
+      </div>
+      <div class="detail-calc">
+        <div>
+          <div class="calc-label">Days</div>
+          <div class="calc-value" id="adv-view-days"></div>
+        </div>
+        <div>
+          <div class="calc-label">Rate p.a.</div>
+          <div class="calc-value" id="adv-view-rate"></div>
+        </div>
+      </div>
+      <div class="form-actions">
+        <button type="button" class="btn-secondary" onclick="closeAdvForm()">Close</button>
+        <button type="button" class="btn-primary" id="adv-view-edit-btn">
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.5 1.5l2 2L4 12H2v-2z"/></svg>
+          Edit
+        </button>
+      </div>
+    </div>
+
+    <!-- Edit mode -->
+    <form id="adv-form" onsubmit="saveAdv(event)" style="display:none">
       <input type="hidden" id="adv-edit-id" value="" />
 
       <div class="form-row">
@@ -200,14 +261,22 @@ function dismissClWarning() {
   document.getElementById('cl-warning').style.display = 'none';
 }
 
+function showAdvPanel(mode) {
+  const view = document.getElementById('adv-view');
+  const form = document.getElementById('adv-form');
+  view.style.display = mode === 'view' ? 'block' : 'none';
+  form.style.display = mode === 'edit' ? 'block' : 'none';
+}
+
 function openAdvForm() {
-  document.getElementById('adv-form-title').textContent = 'New Fixed Advance';
+  document.getElementById('adv-panel-title').textContent = 'New Fixed Advance';
   document.getElementById('adv-form').reset();
   document.getElementById('adv-edit-id').value = '';
   document.getElementById('cont-hint').style.display = 'none';
   document.getElementById('calc-days').textContent = '—';
   document.getElementById('calc-rate').textContent = '—';
   dismissClWarning();
+  showAdvPanel('edit');
   document.getElementById('adv-panel').classList.add('show');
 }
 
@@ -215,11 +284,41 @@ function closeAdvForm() {
   document.getElementById('adv-panel').classList.remove('show');
 }
 
+let currentViewAdvId = null;
+
+async function viewAdv(id) {
+  const res = await fetch('/advances/' + id);
+  if (!res.ok) return;
+  const d = await res.json();
+  currentViewAdvId = id;
+
+  document.getElementById('adv-panel-title').textContent = id;
+  document.getElementById('adv-view-bank').textContent = d.bank;
+  document.getElementById('adv-view-cl').textContent = d.credit_line_id;
+  document.getElementById('adv-view-currency').innerHTML =
+    '<span class="badge badge-' + d.currency.toLowerCase() + '">' + d.currency + '</span>';
+  document.getElementById('adv-view-amount').textContent = parseInt(d.amount_original).toLocaleString();
+  document.getElementById('adv-view-interest').textContent =
+    parseFloat(d.interest_amount).toLocaleString(undefined, {minimumFractionDigits: 2, maximumFractionDigits: 2});
+  document.getElementById('adv-view-status').innerHTML = d.active
+    ? '<span class="badge badge-active">Active</span>'
+    : '<span class="badge badge-expired">Expired</span>';
+  document.getElementById('adv-view-start').textContent = formatDate(d.start_date);
+  document.getElementById('adv-view-end').textContent = formatDate(d.end_date);
+  document.getElementById('adv-view-cont').textContent = formatDate(d.continuation_date);
+  document.getElementById('adv-view-days').textContent = d.days;
+  document.getElementById('adv-view-rate').textContent =
+    d.rate_pa != null ? parseFloat(d.rate_pa).toFixed(4) + '%' : '—';
+
+  showAdvPanel('view');
+  document.getElementById('adv-panel').classList.add('show');
+}
+
 async function editAdv(id) {
   const res = await fetch('/advances/' + id);
   if (!res.ok) return;
   const d = await res.json();
-  document.getElementById('adv-form-title').textContent = 'Edit ' + id;
+  document.getElementById('adv-panel-title').textContent = 'Edit ' + id;
   document.getElementById('adv-edit-id').value = id;
   document.getElementById('adv-bank').value = d.bank;
   document.getElementById('adv-cl').value = d.credit_line_id;
@@ -231,8 +330,21 @@ async function editAdv(id) {
   setAmountField('adv-interest', d.interest_amount, true);
   updateCalcPreview();
   dismissClWarning();
+  showAdvPanel('edit');
   document.getElementById('adv-panel').classList.add('show');
 }
+
+// "Edit" button inside view mode
+document.getElementById('adv-view-edit-btn').addEventListener('click', function() {
+  if (currentViewAdvId) editAdv(currentViewAdvId);
+});
+
+// Row click → open view mode (skip clicks on action buttons)
+document.getElementById('advances-table').addEventListener('click', function(e) {
+  if (e.target.closest('.row-actions')) return;
+  const row = e.target.closest('tr[data-id]');
+  if (row) viewAdv(row.dataset.id);
+});
 
 let clWarningAcknowledged = false;
 

--- a/templates/credit_lines.html
+++ b/templates/credit_lines.html
@@ -40,7 +40,7 @@
     </thead>
     <tbody>
       {% for cl in lines %}
-      <tr data-archived="{{ 'true' if cl.archived else 'false' }}">
+      <tr data-id="{{ cl.id }}" data-archived="{{ 'true' if cl.archived else 'false' }}">
         <td class="mono text-muted">{{ cl.id }}</td>
         <td>{{ cl.bank_name or cl.bank_key }}</td>
         <td>{{ cl.description or '' }}</td>
@@ -84,10 +84,61 @@
 <div class="panel-overlay" id="cl-panel">
   <div class="slide-panel">
     <h3>
-      <span id="cl-form-title">New Credit Line</span>
+      <span id="cl-panel-title">New Credit Line</span>
       <button class="panel-close" onclick="closeCLForm()">&times;</button>
     </h3>
-    <form id="cl-form" onsubmit="saveCL(event)">
+
+    <!-- View mode -->
+    <div id="cl-view" class="panel-view" style="display:none">
+      <div class="detail-grid">
+        <div class="detail-item">
+          <div class="detail-label">Bank</div>
+          <div class="detail-value" id="cl-view-bank"></div>
+        </div>
+        <div class="detail-item">
+          <div class="detail-label">Description</div>
+          <div class="detail-value" id="cl-view-description"></div>
+        </div>
+        <div class="detail-item">
+          <div class="detail-label">Currency</div>
+          <div class="detail-value" id="cl-view-currency"></div>
+        </div>
+        <div class="detail-item">
+          <div class="detail-label">Amount</div>
+          <div class="detail-value mono" id="cl-view-amount"></div>
+        </div>
+        <div class="detail-item">
+          <div class="detail-label">Committed</div>
+          <div class="detail-value" id="cl-view-committed"></div>
+        </div>
+        <div class="detail-item">
+          <div class="detail-label">Status</div>
+          <div class="detail-value" id="cl-view-status"></div>
+        </div>
+        <div class="detail-item">
+          <div class="detail-label">Start Date</div>
+          <div class="detail-value" id="cl-view-start"></div>
+        </div>
+        <div class="detail-item">
+          <div class="detail-label">End Date</div>
+          <div class="detail-value" id="cl-view-end"></div>
+        </div>
+        <div class="detail-item full-width">
+          <div class="detail-label">Note</div>
+          <div class="detail-value" id="cl-view-note"></div>
+        </div>
+      </div>
+      <div class="form-actions" id="cl-view-actions">
+        <button type="button" class="btn-secondary" onclick="closeCLForm()">Close</button>
+        <button type="button" class="btn-primary" id="cl-view-edit-btn">
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.5 1.5l2 2L4 12H2v-2z"/></svg>
+          Edit
+        </button>
+      </div>
+    </div>
+
+    <!-- Edit mode -->
+    <form id="cl-form" onsubmit="saveCL(event)" style="display:none">
       <input type="hidden" id="cl-edit-id" value="" />
       <div class="form-group">
         <label>Bank</label>
@@ -162,11 +213,19 @@ function formatCLAmount(el) {
 
 let editingCLId = null;
 
+function showCLPanel(mode) {
+  const view = document.getElementById('cl-view');
+  const form = document.getElementById('cl-form');
+  view.style.display = mode === 'view' ? 'block' : 'none';
+  form.style.display = mode === 'edit' ? 'block' : 'none';
+}
+
 function openCLForm() {
   editingCLId = null;
-  document.getElementById('cl-form-title').textContent = 'New Credit Line';
+  document.getElementById('cl-panel-title').textContent = 'New Credit Line';
   document.getElementById('cl-form').reset();
   document.getElementById('cl-edit-id').value = '';
+  showCLPanel('edit');
   document.getElementById('cl-panel').classList.add('show');
 }
 
@@ -174,12 +233,41 @@ function closeCLForm() {
   document.getElementById('cl-panel').classList.remove('show');
 }
 
+let currentViewCLId = null;
+
+async function viewCL(id) {
+  const res = await fetch('/credit-lines/' + id);
+  if (!res.ok) return;
+  const data = await res.json();
+  currentViewCLId = id;
+
+  document.getElementById('cl-panel-title').textContent = id;
+  document.getElementById('cl-view-bank').textContent = data.bank_name || data.bank_key;
+  document.getElementById('cl-view-description').textContent = data.description || '—';
+  document.getElementById('cl-view-currency').innerHTML =
+    '<span class="badge badge-' + data.currency.toLowerCase() + '">' + data.currency + '</span>';
+  document.getElementById('cl-view-amount').textContent = parseInt(data.amount).toLocaleString();
+  document.getElementById('cl-view-committed').textContent = data.committed;
+  document.getElementById('cl-view-status').innerHTML = data.archived
+    ? '<span class="badge badge-archived">Archived</span>'
+    : '<span class="badge badge-active">Active</span>';
+  document.getElementById('cl-view-start').textContent = formatDate(data.start_date);
+  document.getElementById('cl-view-end').textContent = formatDate(data.end_date);
+  document.getElementById('cl-view-note').textContent = data.note || '—';
+
+  // Hide Edit button for archived lines
+  document.getElementById('cl-view-edit-btn').style.display = data.archived ? 'none' : '';
+
+  showCLPanel('view');
+  document.getElementById('cl-panel').classList.add('show');
+}
+
 async function editCL(id) {
   const res = await fetch('/credit-lines/' + id);
   if (!res.ok) return;
   const data = await res.json();
   editingCLId = id;
-  document.getElementById('cl-form-title').textContent = 'Edit ' + id;
+  document.getElementById('cl-panel-title').textContent = 'Edit ' + id;
   document.getElementById('cl-edit-id').value = id;
   document.getElementById('cl-bank').value = data.bank_key;
   document.getElementById('cl-description').value = data.description || '';
@@ -189,8 +277,21 @@ async function editCL(id) {
   document.getElementById('cl-start').value = data.start_date;
   document.getElementById('cl-end').value = data.end_date || '';
   document.getElementById('cl-note').value = data.note || '';
+  showCLPanel('edit');
   document.getElementById('cl-panel').classList.add('show');
 }
+
+// "Edit" button inside view mode
+document.getElementById('cl-view-edit-btn').addEventListener('click', function() {
+  if (currentViewCLId) editCL(currentViewCLId);
+});
+
+// Row click → open view mode (skip clicks on action buttons)
+document.getElementById('cl-table').addEventListener('click', function(e) {
+  if (e.target.closest('.row-actions')) return;
+  const row = e.target.closest('tr[data-id]');
+  if (row) viewCL(row.dataset.id);
+});
 
 async function saveCL(e) {
   e.preventDefault();

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -141,6 +141,7 @@
 
       <!-- Option 3: Calendar + compact list -->
       <div class="continuation-view" id="continuation-view-calendar">
+        {% if continuation_calendar is defined %}
         <div class="mini-calendar">
           <div class="mini-cal-header">
             <strong>{{ continuation_calendar.month_label }}</strong>
@@ -157,6 +158,7 @@
           </div>
         </div>
         <div class="calendar-legend">Accent markers = continuation dates</div>
+        {% endif %}
         <div class="calendar-list">
           {% for a in alerts %}
           <div class="calendar-list-item">


### PR DESCRIPTION
## Summary
- Clicking a table row in Fixed Advances or Credit Lines opens the slide-out panel in **read-only view mode** with labels + values
- An "Edit" button in the view switches to the existing edit form; row action Edit buttons still open edit mode directly
- Adds defensive `{% if continuation_calendar is defined %}` guard in dashboard template to prevent `UndefinedError`

Closes #17

## Why
Users had no way to quickly view advance/credit line details without entering edit mode. This separates viewing from editing, reducing accidental changes and improving usability.

## Risk
Low — purely additive frontend changes. No backend modifications. All existing edit/create/delete flows are unchanged.

## How to verify
1. Navigate to Fixed Advances — click any row → view panel opens with read-only details
2. Click "Edit" inside the panel → switches to edit form
3. Click the pencil icon in row actions → opens edit mode directly
4. Click "New Advance" → opens empty edit form (not view mode)
5. Repeat steps 1–4 on Credit Lines page
6. For archived credit lines, verify the Edit button is hidden in view mode
7. Visit dashboard — confirm no `continuation_calendar` errors

## Test output
```
Ran 67 tests in 0.225s

OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)