### PR TITLE
Add centered view/edit modals across all pages

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1,15 +1,15 @@
-// Close slide-out panels when clicking overlay background
+// Close panels/modals when clicking overlay background
 document.addEventListener('click', function(e) {
-  if (e.target.classList.contains('panel-overlay')) {
+  if (e.target.classList.contains('panel-overlay') || e.target.classList.contains('modal-overlay')) {
     e.target.classList.remove('show');
   }
 });
 
-// Close panels on Escape key
+// Close panels/modals on Escape key
 document.addEventListener('keydown', function(e) {
   if (e.key === 'Escape') {
-    document.querySelectorAll('.panel-overlay.show').forEach(function(panel) {
-      panel.classList.remove('show');
+    document.querySelectorAll('.panel-overlay.show, .modal-overlay.show').forEach(function(el) {
+      el.classList.remove('show');
     });
   }
 });

--- a/templates/advances.html
+++ b/templates/advances.html
@@ -76,16 +76,14 @@
   </table>
 </div>
 
-<!-- Slide-out Panel -->
-<div class="panel-overlay" id="adv-panel">
-  <div class="slide-panel">
+<!-- View Modal -->
+<div class="modal-overlay" id="adv-view-modal">
+  <div class="modal-box" style="width: 480px;">
     <h3>
-      <span id="adv-panel-title">New Fixed Advance</span>
-      <button class="panel-close" onclick="closeAdvForm()">&times;</button>
+      <span id="adv-view-title"></span>
+      <button class="panel-close" onclick="closeAdvView()">&times;</button>
     </h3>
-
-    <!-- View mode -->
-    <div id="adv-view" class="panel-view" style="display:none">
+    <div class="panel-view">
       <div class="detail-grid">
         <div class="detail-item">
           <div class="detail-label">Bank</div>
@@ -135,16 +133,24 @@
         </div>
       </div>
       <div class="form-actions">
-        <button type="button" class="btn-secondary" onclick="closeAdvForm()">Close</button>
+        <button type="button" class="btn-secondary" onclick="closeAdvView()">Close</button>
         <button type="button" class="btn-primary" id="adv-view-edit-btn">
           <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.5 1.5l2 2L4 12H2v-2z"/></svg>
           Edit
         </button>
       </div>
     </div>
+  </div>
+</div>
 
-    <!-- Edit mode -->
-    <form id="adv-form" onsubmit="saveAdv(event)" style="display:none">
+<!-- Edit Modal -->
+<div class="modal-overlay" id="adv-panel">
+  <div class="modal-box" style="width: 520px; max-height: 90vh; overflow-y: auto;">
+    <h3>
+      <span id="adv-panel-title">New Fixed Advance</span>
+      <button class="panel-close" onclick="closeAdvForm()">&times;</button>
+    </h3>
+    <form id="adv-form" onsubmit="saveAdv(event)">
       <input type="hidden" id="adv-edit-id" value="" />
 
       <div class="form-row">
@@ -239,6 +245,7 @@
 </div>
 {% endblock %}
 
+
 {% block scripts %}
 <script>
 const parseNum = window.TDNumber.parseLocaleNumber;
@@ -261,13 +268,6 @@ function dismissClWarning() {
   document.getElementById('cl-warning').style.display = 'none';
 }
 
-function showAdvPanel(mode) {
-  const view = document.getElementById('adv-view');
-  const form = document.getElementById('adv-form');
-  view.style.display = mode === 'view' ? 'block' : 'none';
-  form.style.display = mode === 'edit' ? 'block' : 'none';
-}
-
 function openAdvForm() {
   document.getElementById('adv-panel-title').textContent = 'New Fixed Advance';
   document.getElementById('adv-form').reset();
@@ -276,12 +276,15 @@ function openAdvForm() {
   document.getElementById('calc-days').textContent = '—';
   document.getElementById('calc-rate').textContent = '—';
   dismissClWarning();
-  showAdvPanel('edit');
   document.getElementById('adv-panel').classList.add('show');
 }
 
 function closeAdvForm() {
   document.getElementById('adv-panel').classList.remove('show');
+}
+
+function closeAdvView() {
+  document.getElementById('adv-view-modal').classList.remove('show');
 }
 
 let currentViewAdvId = null;
@@ -292,7 +295,7 @@ async function viewAdv(id) {
   const d = await res.json();
   currentViewAdvId = id;
 
-  document.getElementById('adv-panel-title').textContent = id;
+  document.getElementById('adv-view-title').textContent = id;
   document.getElementById('adv-view-bank').textContent = d.bank;
   document.getElementById('adv-view-cl').textContent = d.credit_line_id;
   document.getElementById('adv-view-currency').innerHTML =
@@ -310,8 +313,7 @@ async function viewAdv(id) {
   document.getElementById('adv-view-rate').textContent =
     d.rate_pa != null ? parseFloat(d.rate_pa).toFixed(4) + '%' : '—';
 
-  showAdvPanel('view');
-  document.getElementById('adv-panel').classList.add('show');
+  document.getElementById('adv-view-modal').classList.add('show');
 }
 
 async function editAdv(id) {
@@ -330,13 +332,15 @@ async function editAdv(id) {
   setAmountField('adv-interest', d.interest_amount, true);
   updateCalcPreview();
   dismissClWarning();
-  showAdvPanel('edit');
   document.getElementById('adv-panel').classList.add('show');
 }
 
-// "Edit" button inside view mode
+// "Edit" button inside view mode — close view, open edit
 document.getElementById('adv-view-edit-btn').addEventListener('click', function() {
-  if (currentViewAdvId) editAdv(currentViewAdvId);
+  if (currentViewAdvId) {
+    closeAdvView();
+    editAdv(currentViewAdvId);
+  }
 });
 
 // Row click → open view mode (skip clicks on action buttons)

--- a/templates/banks.html
+++ b/templates/banks.html
@@ -25,7 +25,7 @@
     </thead>
     <tbody>
       {% for bank in banks %}
-      <tr data-key="{{ bank.bank_key }}">
+      <tr data-key="{{ bank.bank_key }}" data-id="{{ bank.bank_key }}">
         <td class="mono text-muted">{{ bank.bank_key }}</td>
         <td>{{ bank.bank_name }}</td>
         <td>
@@ -48,9 +48,38 @@
   </table>
 </div>
 
-<!-- Slide-out Panel -->
-<div class="panel-overlay" id="bank-panel">
-  <div class="slide-panel">
+<!-- View Modal -->
+<div class="modal-overlay" id="bank-view-modal">
+  <div class="modal-box" style="width: 400px;">
+    <h3>
+      <span id="bank-view-title"></span>
+      <button class="panel-close" onclick="closeBankView()">&times;</button>
+    </h3>
+    <div class="panel-view">
+      <div class="detail-grid">
+        <div class="detail-item">
+          <div class="detail-label">Bank Key</div>
+          <div class="detail-value mono" id="bank-view-key"></div>
+        </div>
+        <div class="detail-item">
+          <div class="detail-label">Bank Name</div>
+          <div class="detail-value" id="bank-view-name"></div>
+        </div>
+      </div>
+      <div class="form-actions">
+        <button type="button" class="btn-secondary" onclick="closeBankView()">Close</button>
+        <button type="button" class="btn-primary" id="bank-view-edit-btn">
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.5 1.5l2 2L4 12H2v-2z"/></svg>
+          Edit
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Edit Modal -->
+<div class="modal-overlay" id="bank-panel">
+  <div class="modal-box" style="width: 400px;">
     <h3>
       <span id="bank-form-title">Add Bank</span>
       <button class="panel-close" onclick="closeBankForm()">&times;</button>
@@ -78,6 +107,8 @@
 
 {% block scripts %}
 <script>
+let currentViewBankKey = null;
+
 function openBankForm(key, name) {
   document.getElementById('bank-form-title').textContent = key ? 'Edit Bank' : 'Add Bank';
   document.getElementById('bank-key').value = key || '';
@@ -91,9 +122,41 @@ function closeBankForm() {
   document.getElementById('bank-panel').classList.remove('show');
 }
 
+function closeBankView() {
+  document.getElementById('bank-view-modal').classList.remove('show');
+}
+
+function viewBank(key, name) {
+  currentViewBankKey = key;
+  document.getElementById('bank-view-title').textContent = name;
+  document.getElementById('bank-view-key').textContent = key;
+  document.getElementById('bank-view-name').textContent = name;
+  document.getElementById('bank-view-modal').classList.add('show');
+}
+
 function editBank(key, name) {
   openBankForm(key, name);
 }
+
+// "Edit" button inside view mode — close view, open edit
+document.getElementById('bank-view-edit-btn').addEventListener('click', function() {
+  if (currentViewBankKey) {
+    const name = document.getElementById('bank-view-name').textContent;
+    closeBankView();
+    editBank(currentViewBankKey, name);
+  }
+});
+
+// Row click → open view mode (skip clicks on action buttons)
+document.getElementById('banks-table').addEventListener('click', function(e) {
+  if (e.target.closest('.row-actions')) return;
+  const row = e.target.closest('tr[data-key]');
+  if (row) {
+    const key = row.dataset.key;
+    const name = row.children[1].textContent;
+    viewBank(key, name);
+  }
+});
 
 async function saveBank(e) {
   e.preventDefault();

--- a/templates/credit_lines.html
+++ b/templates/credit_lines.html
@@ -80,16 +80,14 @@
   </table>
 </div>
 
-<!-- Slide-out Panel -->
-<div class="panel-overlay" id="cl-panel">
-  <div class="slide-panel">
+<!-- View Modal -->
+<div class="modal-overlay" id="cl-view-modal">
+  <div class="modal-box" style="width: 480px;">
     <h3>
-      <span id="cl-panel-title">New Credit Line</span>
-      <button class="panel-close" onclick="closeCLForm()">&times;</button>
+      <span id="cl-view-title"></span>
+      <button class="panel-close" onclick="closeCLView()">&times;</button>
     </h3>
-
-    <!-- View mode -->
-    <div id="cl-view" class="panel-view" style="display:none">
+    <div class="panel-view">
       <div class="detail-grid">
         <div class="detail-item">
           <div class="detail-label">Bank</div>
@@ -128,17 +126,25 @@
           <div class="detail-value" id="cl-view-note"></div>
         </div>
       </div>
-      <div class="form-actions" id="cl-view-actions">
-        <button type="button" class="btn-secondary" onclick="closeCLForm()">Close</button>
+      <div class="form-actions">
+        <button type="button" class="btn-secondary" onclick="closeCLView()">Close</button>
         <button type="button" class="btn-primary" id="cl-view-edit-btn">
           <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.5 1.5l2 2L4 12H2v-2z"/></svg>
           Edit
         </button>
       </div>
     </div>
+  </div>
+</div>
 
-    <!-- Edit mode -->
-    <form id="cl-form" onsubmit="saveCL(event)" style="display:none">
+<!-- Edit Modal -->
+<div class="modal-overlay" id="cl-panel">
+  <div class="modal-box" style="width: 520px; max-height: 90vh; overflow-y: auto;">
+    <h3>
+      <span id="cl-panel-title">New Credit Line</span>
+      <button class="panel-close" onclick="closeCLForm()">&times;</button>
+    </h3>
+    <form id="cl-form" onsubmit="saveCL(event)">
       <input type="hidden" id="cl-edit-id" value="" />
       <div class="form-group">
         <label>Bank</label>
@@ -211,26 +217,19 @@ function formatCLAmount(el) {
   window.TDNumber.formatIntegerInput(el);
 }
 
-let editingCLId = null;
-
-function showCLPanel(mode) {
-  const view = document.getElementById('cl-view');
-  const form = document.getElementById('cl-form');
-  view.style.display = mode === 'view' ? 'block' : 'none';
-  form.style.display = mode === 'edit' ? 'block' : 'none';
-}
-
 function openCLForm() {
-  editingCLId = null;
   document.getElementById('cl-panel-title').textContent = 'New Credit Line';
   document.getElementById('cl-form').reset();
   document.getElementById('cl-edit-id').value = '';
-  showCLPanel('edit');
   document.getElementById('cl-panel').classList.add('show');
 }
 
 function closeCLForm() {
   document.getElementById('cl-panel').classList.remove('show');
+}
+
+function closeCLView() {
+  document.getElementById('cl-view-modal').classList.remove('show');
 }
 
 let currentViewCLId = null;
@@ -241,7 +240,7 @@ async function viewCL(id) {
   const data = await res.json();
   currentViewCLId = id;
 
-  document.getElementById('cl-panel-title').textContent = id;
+  document.getElementById('cl-view-title').textContent = id;
   document.getElementById('cl-view-bank').textContent = data.bank_name || data.bank_key;
   document.getElementById('cl-view-description').textContent = data.description || '—';
   document.getElementById('cl-view-currency').innerHTML =
@@ -258,15 +257,13 @@ async function viewCL(id) {
   // Hide Edit button for archived lines
   document.getElementById('cl-view-edit-btn').style.display = data.archived ? 'none' : '';
 
-  showCLPanel('view');
-  document.getElementById('cl-panel').classList.add('show');
+  document.getElementById('cl-view-modal').classList.add('show');
 }
 
 async function editCL(id) {
   const res = await fetch('/credit-lines/' + id);
   if (!res.ok) return;
   const data = await res.json();
-  editingCLId = id;
   document.getElementById('cl-panel-title').textContent = 'Edit ' + id;
   document.getElementById('cl-edit-id').value = id;
   document.getElementById('cl-bank').value = data.bank_key;
@@ -277,13 +274,15 @@ async function editCL(id) {
   document.getElementById('cl-start').value = data.start_date;
   document.getElementById('cl-end').value = data.end_date || '';
   document.getElementById('cl-note').value = data.note || '';
-  showCLPanel('edit');
   document.getElementById('cl-panel').classList.add('show');
 }
 
-// "Edit" button inside view mode
+// "Edit" button inside view mode — close view, open edit
 document.getElementById('cl-view-edit-btn').addEventListener('click', function() {
-  if (currentViewCLId) editCL(currentViewCLId);
+  if (currentViewCLId) {
+    closeCLView();
+    editCL(currentViewCLId);
+  }
 });
 
 // Row click → open view mode (skip clicks on action buttons)

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -292,15 +292,6 @@
 
 {% block scripts %}
 <script>
-// Close view modal on overlay click or Escape
-document.getElementById('dash-panel').addEventListener('click', function(e) {
-  if (e.target === this) closeDashPanel();
-});
-document.addEventListener('keydown', function(e) {
-  if (e.key === 'Escape') closeDashPanel();
-});
-</script>
-<script>
 // ── Column sorting ──
 const numericSortKeys = new Set(['amount', 'rate']);
 


### PR DESCRIPTION
## Summary
- Clicking a row on any data table opens a centered view-only modal with record details
- Edit forms are also now centered modals (converted from slide-out panels) for consistent UX
- Dashboard Edit button navigates to `/advances#edit-<id>` to open the edit form directly
- Banks page gains a view modal (previously had no view mode)
- Generic overlay-click and Escape handlers consolidated in `app.js`

## Why
Extends the view-on-click pattern (PR #29) to the dashboard and banks pages, and converts all panels (view + edit) from slide-out to centered modals for a consistent, Settings-like UX across the app.

## Risk
Low — additive frontend changes only. No backend modifications.

## How to verify
1. **Dashboard**: Click any row → centered view modal opens → Click Edit → navigates to advances edit
2. **Advances**: Click row → view modal → Click Edit → edit modal opens. Click "New Advance" → edit modal opens
3. **Credit Lines**: Same pattern. Archived lines hide the Edit button in view modal
4. **Banks**: Click row → view modal with key + name → Click Edit → edit modal. Click "Add Bank" → edit modal
5. **All pages**: Click overlay background or press Escape → modal closes
6. **Currency modal**: Open edit modal → click "+" to add currency → works correctly on top of edit modal

## Test output
```
Ran 67 tests in 0.228s

OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)