### PR TITLE
Add month navigation to Upcoming Continuations calendar

### DIFF
--- a/db.py
+++ b/db.py
@@ -421,6 +421,24 @@ def get_continuation_alerts(conn, days=7):
     ).fetchall()
 
 
+def get_continuations_for_month(conn, year, month):
+    """Return active advances with continuation_date in the given month."""
+    month_start = f"{year:04d}-{month:02d}-01"
+    if month == 12:
+        month_end = f"{year + 1:04d}-01-01"
+    else:
+        month_end = f"{year:04d}-{month + 1:02d}-01"
+    return conn.execute(
+        "SELECT fa.*, cl.description as cl_description "
+        "FROM fixed_advances fa "
+        "LEFT JOIN credit_lines cl ON fa.credit_line_id = cl.id "
+        "WHERE fa.start_date <= date('now') AND fa.end_date > date('now') "
+        "AND fa.continuation_date >= ? AND fa.continuation_date < ? "
+        "ORDER BY fa.continuation_date ASC",
+        (month_start, month_end),
+    ).fetchall()
+
+
 def get_cl_drawn(conn, cl_id, exclude_fv_id=None):
     if exclude_fv_id:
         row = conn.execute(

--- a/static/style.css
+++ b/static/style.css
@@ -456,9 +456,34 @@ body {
 }
 
 .mini-cal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   margin-bottom: 6px;
   font-size: 12px;
   color: var(--berry-dark);
+}
+
+.cal-nav-btn {
+  background: none;
+  border: 1px solid var(--berry-border);
+  border-radius: 4px;
+  width: 22px;
+  height: 22px;
+  font-size: 14px;
+  line-height: 1;
+  color: var(--berry);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.15s;
+  padding: 0;
+}
+.cal-nav-btn:hover {
+  background: var(--berry);
+  color: #fff;
+  border-color: var(--berry);
 }
 
 .mini-cal-grid {

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -144,12 +144,16 @@
         {% if continuation_calendar is defined %}
         <div class="mini-calendar">
           <div class="mini-cal-header">
-            <strong>{{ continuation_calendar.month_label }}</strong>
+            <button class="cal-nav-btn" type="button" onclick="navigateCalendar(-1)" aria-label="Previous month">&lsaquo;</button>
+            <strong id="cal-month-label"
+                    data-year="{{ continuation_calendar.year }}"
+                    data-month="{{ continuation_calendar.month }}">{{ continuation_calendar.month_label }}</strong>
+            <button class="cal-nav-btn" type="button" onclick="navigateCalendar(1)" aria-label="Next month">&rsaquo;</button>
           </div>
           <div class="mini-cal-grid mini-cal-weekdays">
             <div>Mo</div><div>Tu</div><div>We</div><div>Th</div><div>Fr</div><div>Sa</div><div>Su</div>
           </div>
-          <div class="mini-cal-grid mini-cal-days">
+          <div class="mini-cal-grid mini-cal-days" id="cal-days-grid">
             {% for cell in continuation_calendar.cells %}
             <div class="mini-cal-day {{ 'marked' if cell.marked }} {{ 'today' if cell.today }}">
               {{ cell.day }}
@@ -159,10 +163,10 @@
         </div>
         <div class="calendar-legend">Accent markers = continuation dates</div>
         {% endif %}
-        <div class="calendar-list">
+        <div class="calendar-list" id="cal-list">
           {% for a in alerts %}
           <div class="calendar-list-item">
-            <strong>{{ a.cont_day }} {{ a.cont_mon }}</strong> · {{ a.id }} · {{ a.bank }}
+            <strong>{{ a.cont_day }} {{ a.cont_mon }}</strong> · {{ a.id }} · {{ a.bank }} · {{ a.currency }} {{ a.amount_original|amount }}
           </div>
           {% endfor %}
         </div>
@@ -397,6 +401,48 @@ function switchContinuationView(view, btn) {
   document.querySelectorAll('.continuation-view').forEach(v => v.classList.remove('is-active'));
   const target = document.getElementById('continuation-view-' + view);
   if (target) target.classList.add('is-active');
+}
+
+// ── Calendar month navigation ──
+
+async function navigateCalendar(delta) {
+  const label = document.getElementById('cal-month-label');
+  if (!label) return;
+
+  let year = parseInt(label.dataset.year, 10);
+  let month = parseInt(label.dataset.month, 10) + delta;
+
+  if (month < 1) { month = 12; year--; }
+  if (month > 12) { month = 1; year++; }
+
+  const res = await fetch('/api/continuation-calendar?year=' + year + '&month=' + month);
+  if (!res.ok) return;
+  const data = await res.json();
+  const cal = data.calendar;
+
+  // Update label
+  label.textContent = cal.month_label;
+  label.dataset.year = cal.year;
+  label.dataset.month = cal.month;
+
+  // Rebuild day grid
+  const grid = document.getElementById('cal-days-grid');
+  grid.innerHTML = cal.cells.map(function(c) {
+    const cls = ['mini-cal-day'];
+    if (c.marked) cls.push('marked');
+    if (c.today) cls.push('today');
+    return '<div class="' + cls.join(' ') + '">' + (c.day || '') + '</div>';
+  }).join('');
+
+  // Rebuild list
+  const list = document.getElementById('cal-list');
+  if (data.items.length === 0) {
+    list.innerHTML = '<div class="calendar-list-item" style="color:var(--text-muted)">No continuations this month</div>';
+  } else {
+    list.innerHTML = data.items.map(function(it) {
+      return '<div class="calendar-list-item"><strong>' + it.day + ' ' + it.mon + '</strong> · ' + it.id + ' · ' + it.bank + ' · ' + it.currency + ' ' + it.amount + '</div>';
+    }).join('');
+  }
 }
 </script>
 {% endblock %}

--- a/tests/test_continuation_calendar.py
+++ b/tests/test_continuation_calendar.py
@@ -110,6 +110,68 @@ class ContinuationCalendarTests(unittest.TestCase):
                 f"Month {month} cells not a multiple of 7"
             )
 
+    # ── New: explicit year/month parameter tests ──
+
+    @patch("app.date")
+    def test_explicit_month_overrides_today(self, mock_date):
+        """Passing year/month builds that month, not today's."""
+        mock_date.today.return_value = date(2026, 3, 15)
+        mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+
+        result = build_continuation_calendar([], year=2026, month=7)
+
+        self.assertEqual(result["month_label"], "July 2026")
+        self.assertEqual(result["year"], 2026)
+        self.assertEqual(result["month"], 7)
+        day_cells = [c for c in result["cells"] if c["day"] != ""]
+        self.assertEqual(len(day_cells), 31)
+
+    @patch("app.date")
+    def test_today_not_flagged_on_other_month(self, mock_date):
+        """Today indicator should not appear when viewing a different month."""
+        mock_date.today.return_value = date(2026, 3, 15)
+        mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+
+        result = build_continuation_calendar([], year=2026, month=4)
+
+        today_cells = [c for c in result["cells"] if c["today"]]
+        self.assertEqual(len(today_cells), 0)
+
+    @patch("app.date")
+    def test_today_flagged_on_current_month_explicit(self, mock_date):
+        """Today indicator appears when explicitly requesting current month."""
+        mock_date.today.return_value = date(2026, 3, 15)
+        mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+
+        result = build_continuation_calendar([], year=2026, month=3)
+
+        today_cells = [c for c in result["cells"] if c["today"]]
+        self.assertEqual(len(today_cells), 1)
+        self.assertEqual(today_cells[0]["day"], 15)
+
+    @patch("app.date")
+    def test_return_includes_year_and_month(self, mock_date):
+        """Return dict includes year and month keys."""
+        mock_date.today.return_value = date(2026, 5, 1)
+        mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+
+        result = build_continuation_calendar([])
+
+        self.assertEqual(result["year"], 2026)
+        self.assertEqual(result["month"], 5)
+
+    @patch("app.date")
+    def test_december_explicit(self, mock_date):
+        """December with explicit params calculates correctly."""
+        mock_date.today.return_value = date(2026, 6, 1)
+        mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+
+        result = build_continuation_calendar([], year=2026, month=12)
+
+        self.assertEqual(result["month_label"], "December 2026")
+        day_cells = [c for c in result["cells"] if c["day"] != ""]
+        self.assertEqual(len(day_cells), 31)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed
- Added prev/next arrow buttons to the calendar view so users can browse continuation dates across months
- New `GET /api/continuation-calendar?year=YYYY&month=MM` endpoint returns calendar grid + list items for any month
- Calendar list items now show currency and amount for each advance (server-rendered + JS-rebuilt)
- 5 new unit tests covering explicit month params, today indicator logic, and return shape

Closes #34

## Why
Users were locked to viewing only the current month in the Upcoming Continuations calendar, with no way to see what's coming in future months or review past months.

## Risk
Low — backward-compatible changes only. `build_continuation_calendar()` defaults to current month when no params passed, preserving all existing behavior. New API endpoint is read-only.

## How to verify
1. `python -m unittest discover -s tests -v` — all 72 tests pass
2. Manual: open dashboard, switch to Calendar view, click prev/next arrows, verify grid updates correctly, continuation markers appear on correct days, today indicator only shows on current month, empty months show "No continuations this month", list items include currency and amount

## Test output
```
test_advance_create_invalid_date_order_fails ... ok
test_advance_create_malformed_date_fails ... ok
test_advance_create_missing_required_field_fails ... ok
test_advance_happy_path ... ok
test_advance_update_invalid_date_order_fails ... ok
test_bank_happy_path ... ok
test_check_cl_capacity_happy_path ... ok
test_check_cl_capacity_validation ... ok
test_credit_line_create_missing_required_field_fails ... ok
test_credit_line_happy_path ... ok
test_currency_api_invalid_and_duplicate ... ok
test_non_json_payload_returns_400 ... ok
test_not_found_get_endpoints ... ok
test_suggest_continuation_validation ... ok
test_december_explicit ... ok
test_december_year_rollover ... ok
test_explicit_month_overrides_today ... ok
test_february_leap_year ... ok
test_february_non_leap ... ok
test_grid_always_complete_weeks ... ok
test_marked_dates_flagged ... ok
test_month_starting_monday ... ok
test_normal_month_structure ... ok
test_return_includes_year_and_month ... ok
test_today_flagged ... ok
test_today_flagged_on_current_month_explicit ... ok
test_today_not_flagged_on_other_month ... ok
test_cache_hit_skips_network ... ok
test_malformed_payload_falls_back_to_cached_rates ... ok
test_timeout_falls_back_to_base_rate_when_no_cache ... ok
test_validate_currency_network_error ... ok
test_advance_columns ... ok
test_calculated_fields ... ok
test_creates_export_directory ... ok
test_creates_file ... ok
test_credit_line_columns ... ok
test_empty_tables ... ok
test_includes_archived_credit_lines ... ok
test_row_counts ... ok
test_sheet_names ... ok
test_calc_days ... ok
test_continuation_date_skips_weekends ... ok
test_interest_rate_calc_and_guards ... ok
test_is_currently_active_boundaries ... ok
test_full ... ok
test_invalid_value_passthrough ... ok
test_millions_default ... ok
test_thousands ... ok
test_format_millions ... ok
test_format_small ... ok
test_format_thousands ... ok
test_browse_dirs_explicit_path ... ok
test_browse_dirs_hides_dotfiles ... ok
test_browse_dirs_home ... ok
test_browse_dirs_nonexistent ... ok
test_browse_dirs_relative ... ok
test_browse_dirs_sorted ... ok
test_get_settings_returns_defaults ... ok
test_put_empty_value_rejected ... ok
test_put_invalid_display_unit ... ok
test_put_nonexistent_export_path ... ok
test_put_relative_export_path ... ok
test_put_unknown_key ... ok
test_put_valid_display_unit ... ok
test_put_valid_export_path ... ok
test_put_whitespace_only_value_rejected ... ok
test_get_all_settings_returns_seeded_defaults ... ok
test_get_setting_returns_default_when_missing ... ok
test_get_setting_returns_none_when_missing_no_default ... ok
test_seed_settings_idempotent ... ok
test_set_setting_inserts_new_key ... ok
test_set_setting_upserts_existing_key ... ok

----------------------------------------------------------------------
Ran 72 tests in 0.226s

OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)