### PR TITLE
Add setting for Upcoming Continuations display limit (#30)

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -25,6 +25,7 @@ async function openSettingsModal() {
     const res = await fetch('/api/settings');
     const settings = await res.json();
     document.getElementById('settings-display-unit').value = settings.display_unit || 'millions';
+    document.getElementById('settings-continuation-limit').value = settings.continuation_limit || '5';
     document.getElementById('settings-export-path').value = settings.export_path || '';
   } catch (e) {
     // Use defaults if fetch fails
@@ -140,9 +141,10 @@ async function saveSettings(e) {
   btn.disabled = true;
   msgEl.style.display = 'none';
 
-  const LABELS = { display_unit: 'Display Unit', export_path: 'Export Path' };
+  const LABELS = { display_unit: 'Display Unit', continuation_limit: 'Continuations to show', export_path: 'Export Path' };
   const settings = [
     { key: 'display_unit', value: document.getElementById('settings-display-unit').value },
+    { key: 'continuation_limit', value: document.getElementById('settings-continuation-limit').value },
     { key: 'export_path', value: document.getElementById('settings-export-path').value.trim() },
   ];
 

--- a/static/style.css
+++ b/static/style.css
@@ -414,40 +414,7 @@ body {
   text-transform: uppercase;
 }
 
-/* Option 2: Timeline */
-.continuation-timeline-item {
-  position: relative;
-  display: grid;
-  grid-template-columns: 16px 1fr;
-  gap: 8px;
-  padding: 7px 0 7px 2px;
-}
-
-.continuation-timeline-item + .continuation-timeline-item {
-  border-top: 1px solid var(--berry-border);
-}
-
-.timeline-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 999px;
-  background: var(--berry);
-  margin-top: 4px;
-  box-shadow: 0 0 0 3px var(--berry-bg-soft);
-}
-
-.timeline-title {
-  font-size: 12px;
-  color: var(--berry-dark);
-}
-
-.timeline-sub {
-  margin-top: 2px;
-  font-size: 11px;
-  color: var(--berry-muted);
-}
-
-/* Option 3: Mini calendar */
+/* Mini calendar */
 .mini-calendar {
   background: #fff;
   border: 1px solid var(--berry-border);
@@ -511,6 +478,29 @@ body {
   background: var(--berry);
   color: #fff;
   font-weight: 700;
+  position: relative;
+  cursor: default;
+}
+
+.mini-cal-day.marked[data-tooltip]:hover::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 4px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--text);
+  color: #fff;
+  padding: 6px 10px;
+  border-radius: 6px;
+  font-size: 11px;
+  font-weight: 400;
+  white-space: pre-line;
+  line-height: 1.5;
+  z-index: 10;
+  pointer-events: none;
+  width: max-content;
+  max-width: 220px;
+  box-shadow: 0 2px 8px rgba(0,0,0,.18);
 }
 
 .mini-cal-day.today {

--- a/templates/base.html
+++ b/templates/base.html
@@ -103,6 +103,15 @@
           </select>
         </div>
         <div class="form-group">
+          <label>Continuations to show</label>
+          <select id="settings-continuation-limit">
+            <option value="3">3</option>
+            <option value="5" selected>5</option>
+            <option value="10">10</option>
+            <option value="all">All</option>
+          </select>
+        </div>
+        <div class="form-group">
           <label>Export Path</label>
           <div style="display:flex; gap:8px;">
             <input type="text" id="settings-export-path"

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -95,7 +95,7 @@
       <div class="card-sub">within next 7 days</div>
     </div>
 
-    {% if alerts %}
+    {% if alerts or upcoming %}
     <div class="continuations-widget">
       <div class="alert-title">
         <svg width="14" height="14" viewBox="0 0 14 14" fill="#A62152"><path d="M7 0a7 7 0 100 14A7 7 0 007 0zm0 3a1 1 0 011 1v3a1 1 0 01-2 0V4a1 1 0 011-1zm0 7a1 1 0 110 2 1 1 0 010-2z"/></svg>
@@ -103,13 +103,12 @@
       </div>
       <div class="continuation-view-switch">
         <button class="pill active" type="button" data-view="list" onclick="switchContinuationView('list', this)">List</button>
-        <button class="pill" type="button" data-view="timeline" onclick="switchContinuationView('timeline', this)">Timeline</button>
         <button class="pill" type="button" data-view="calendar" onclick="switchContinuationView('calendar', this)">Calendar</button>
       </div>
 
-      <!-- Option 1: Date-left list card -->
+      <!-- Timeline: Date-left list card -->
       <div class="continuation-view is-active" id="continuation-view-list">
-        {% for a in alerts %}
+        {% for a in upcoming %}
         <div class="continuation-row">
           <div class="continuation-date-chip">
             <div class="day-mon">
@@ -126,20 +125,7 @@
         {% endfor %}
       </div>
 
-      <!-- Option 2: Timeline -->
-      <div class="continuation-view" id="continuation-view-timeline">
-        {% for a in alerts %}
-        <div class="continuation-timeline-item">
-          <div class="timeline-dot"></div>
-          <div class="timeline-content">
-            <div class="timeline-title"><strong>{{ a.id }}</strong> · {{ a.bank }}</div>
-            <div class="timeline-sub">{{ a.continuation_date|date_display }} · {{ a.currency }} {{ a.amount_original|amount }}</div>
-          </div>
-        </div>
-        {% endfor %}
-      </div>
-
-      <!-- Option 3: Calendar + compact list -->
+      <!-- Calendar + compact list -->
       <div class="continuation-view" id="continuation-view-calendar">
         {% if continuation_calendar is defined %}
         <div class="mini-calendar">
@@ -155,7 +141,8 @@
           </div>
           <div class="mini-cal-grid mini-cal-days" id="cal-days-grid">
             {% for cell in continuation_calendar.cells %}
-            <div class="mini-cal-day {{ 'marked' if cell.marked }} {{ 'today' if cell.today }}">
+            <div class="mini-cal-day {{ 'marked' if cell.marked }} {{ 'today' if cell.today }}"
+              {%- if cell.marked and tooltip_map.get(cell.date) %} data-tooltip="{{ tooltip_map[cell.date] }}"{% endif %}>
               {{ cell.day }}
             </div>
             {% endfor %}
@@ -163,8 +150,8 @@
         </div>
         <div class="calendar-legend">Accent markers = continuation dates</div>
         {% endif %}
-        <div class="calendar-list" id="cal-list">
-          {% for a in alerts %}
+        <div class="calendar-list" id="cal-list" data-cont-limit="{{ cont_limit or 0 }}">
+          {% for a in upcoming %}
           <div class="calendar-list-item">
             <strong>{{ a.cont_day }} {{ a.cont_mon }}</strong> · {{ a.id }} · {{ a.bank }} · {{ a.currency }} {{ a.amount_original|amount }}
           </div>
@@ -405,6 +392,12 @@ function switchContinuationView(view, btn) {
 
 // ── Calendar month navigation ──
 
+function esc(s) {
+  const d = document.createElement('div');
+  d.textContent = s;
+  return d.innerHTML;
+}
+
 async function navigateCalendar(delta) {
   const label = document.getElementById('cal-month-label');
   if (!label) return;
@@ -425,22 +418,32 @@ async function navigateCalendar(delta) {
   label.dataset.year = cal.year;
   label.dataset.month = cal.month;
 
+  // Build tooltip map from items
+  const tooltipMap = {};
+  data.items.forEach(function(it) {
+    if (!tooltipMap[it.date]) tooltipMap[it.date] = [];
+    tooltipMap[it.date].push(esc(it.id) + ' \u00b7 ' + esc(it.bank) + ' \u00b7 ' + esc(it.currency) + ' ' + esc(it.amount));
+  });
+
   // Rebuild day grid
   const grid = document.getElementById('cal-days-grid');
   grid.innerHTML = cal.cells.map(function(c) {
     const cls = ['mini-cal-day'];
     if (c.marked) cls.push('marked');
     if (c.today) cls.push('today');
-    return '<div class="' + cls.join(' ') + '">' + (c.day || '') + '</div>';
+    const tip = c.marked && tooltipMap[c.date] ? ' data-tooltip="' + tooltipMap[c.date].join('\n').replace(/"/g, '&quot;') + '"' : '';
+    return '<div class="' + cls.join(' ') + '"' + tip + '>' + (c.day || '') + '</div>';
   }).join('');
 
-  // Rebuild list
+  // Rebuild list (respect display limit)
   const list = document.getElementById('cal-list');
-  if (data.items.length === 0) {
+  const limitAttr = parseInt(list.dataset.contLimit, 10);
+  const displayItems = limitAttr > 0 ? data.items.slice(0, limitAttr) : data.items;
+  if (displayItems.length === 0) {
     list.innerHTML = '<div class="calendar-list-item" style="color:var(--text-muted)">No continuations this month</div>';
   } else {
-    list.innerHTML = data.items.map(function(it) {
-      return '<div class="calendar-list-item"><strong>' + it.day + ' ' + it.mon + '</strong> · ' + it.id + ' · ' + it.bank + ' · ' + it.currency + ' ' + it.amount + '</div>';
+    list.innerHTML = displayItems.map(function(it) {
+      return '<div class="calendar-list-item"><strong>' + esc(it.day + ' ' + it.mon) + '</strong> · ' + esc(it.id) + ' · ' + esc(it.bank) + ' · ' + esc(it.currency) + ' ' + esc(it.amount) + '</div>';
     }).join('');
   }
 }

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -176,6 +176,24 @@ class SettingsApiTests(unittest.TestCase):
         self.assertEqual(res.status_code, 400)
         self.assertIn("non-empty", res.get_json()["error"])
 
+    # ── Continuation Limit ──
+
+    def test_put_valid_continuation_limit(self):
+        for val in ("3", "5", "10", "all"):
+            res = self.client.put("/api/settings", json={"key": "continuation_limit", "value": val})
+            self.assertEqual(res.status_code, 200, f"Expected 200 for value '{val}'")
+            self.assertTrue(res.get_json()["ok"])
+
+    def test_put_invalid_continuation_limit_number(self):
+        res = self.client.put("/api/settings", json={"key": "continuation_limit", "value": "7"})
+        self.assertEqual(res.status_code, 400)
+        self.assertFalse(res.get_json()["ok"])
+
+    def test_put_invalid_continuation_limit_string(self):
+        res = self.client.put("/api/settings", json={"key": "continuation_limit", "value": "abc"})
+        self.assertEqual(res.status_code, 400)
+        self.assertFalse(res.get_json()["ok"])
+
     # ── Browse Dirs ──
 
     def test_browse_dirs_home(self):


### PR DESCRIPTION
## Summary
- New **Continuations to show** setting (3 / 5 / 10 / All) in the Settings modal controls how many entries appear in the Upcoming Continuations widget
- List and Calendar list views now show the **next N continuations from today onward** (not bounded to the 7-day window) via a new `get_upcoming_continuations()` query with SQL `LIMIT`
- **Calendar grid** still marks all dates for the displayed month — only the item list below is limited
- **Hover tooltips** on marked calendar days show advance details (ID, bank, currency, amount); works on both server-rendered and JS-navigated months
- Removed the redundant **Timeline view** (same data as List with less visual hierarchy)
- Fixed `_seed_settings()` to use `INSERT OR IGNORE` per key so existing databases get new settings automatically
- Added `esc()` HTML-escape helper for all API-sourced values in JS `innerHTML` assignments
- 3 new tests for continuation_limit validation (valid values return 200, invalid return 400)

## Test plan
- [x] `python -m unittest discover -s tests -v` — 75 tests pass
- [ ] Open Settings → change "Continuations to show" → save → verify List/Calendar show correct count
- [ ] Calendar grid still marks all dates regardless of limit
- [ ] Hover marked calendar days → tooltip shows advance details
- [ ] Navigate calendar months → tooltips rebuild correctly
- [ ] Existing DB without `continuation_limit` row → defaults to 5, setting appears after first save

🤖 Generated with [Claude Code](https://claude.com/claude-code)