### PR TITLE
Add HSTS, nonce-based CSP, and synthetic demo data

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ from contextlib import contextmanager
 from datetime import date
 import os
 import re
+import secrets
 
 from flask import Flask, g, jsonify, render_template, request
 try:
@@ -32,9 +33,9 @@ IS_PRODUCTION = (
 BROWSE_DIRS_ENABLED = not IS_PRODUCTION
 WRITE_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
 HSTS_POLICY = "max-age=31536000; includeSubDomains"
-CSP_POLICY = "; ".join([
+_CSP_TEMPLATE = "; ".join([
     "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
+    "script-src 'self' 'nonce-{nonce}'",
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "font-src 'self' https://fonts.gstatic.com data:",
     "img-src 'self' data:",
@@ -80,6 +81,16 @@ def rate_limit(limit_value):
 
 
 @app.before_request
+def generate_csp_nonce():
+    g.csp_nonce = secrets.token_urlsafe(16)
+
+
+@app.context_processor
+def inject_csp_nonce():
+    return {"csp_nonce": getattr(g, "csp_nonce", "")}
+
+
+@app.before_request
 def enforce_demo_read_only():
     if not DEMO_MODE:
         return None
@@ -97,7 +108,10 @@ def add_security_headers(response):
     response.headers.setdefault("X-Content-Type-Options", "nosniff")
     response.headers.setdefault("X-Frame-Options", "DENY")
     response.headers.setdefault("Referrer-Policy", "strict-origin-when-cross-origin")
-    response.headers.setdefault("Content-Security-Policy", CSP_POLICY)
+    nonce = getattr(g, "csp_nonce", "")
+    response.headers.setdefault(
+        "Content-Security-Policy", _CSP_TEMPLATE.format(nonce=nonce)
+    )
 
     # Render forwards protocol in X-Forwarded-Proto; only send HSTS on HTTPS.
     forwarded_proto = request.headers.get("X-Forwarded-Proto", "")

--- a/app.py
+++ b/app.py
@@ -31,6 +31,19 @@ IS_PRODUCTION = (
 )
 BROWSE_DIRS_ENABLED = not IS_PRODUCTION
 WRITE_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
+HSTS_POLICY = "max-age=31536000; includeSubDomains"
+CSP_POLICY = "; ".join([
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+    "font-src 'self' https://fonts.gstatic.com data:",
+    "img-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "frame-ancestors 'none'",
+    "form-action 'self'",
+])
 
 app = Flask(__name__)
 app.config["DEMO_MODE"] = DEMO_MODE
@@ -84,6 +97,13 @@ def add_security_headers(response):
     response.headers.setdefault("X-Content-Type-Options", "nosniff")
     response.headers.setdefault("X-Frame-Options", "DENY")
     response.headers.setdefault("Referrer-Policy", "strict-origin-when-cross-origin")
+    response.headers.setdefault("Content-Security-Policy", CSP_POLICY)
+
+    # Render forwards protocol in X-Forwarded-Proto; only send HSTS on HTTPS.
+    forwarded_proto = request.headers.get("X-Forwarded-Proto", "")
+    first_proto = forwarded_proto.split(",")[0].strip().lower() if forwarded_proto else ""
+    if request.is_secure or first_proto == "https":
+        response.headers.setdefault("Strict-Transport-Security", HSTS_POLICY)
     return response
 
 

--- a/seed.py
+++ b/seed.py
@@ -1,16 +1,14 @@
-from datetime import date, timedelta
+import os
 
 import db
 import helpers
-from config import INTEREST_YEAR_BASIS
+import import_utils
 
-
-def _interest(amount, days, annual_rate):
-    return round(amount * (annual_rate / 100.0) * (days / INTEREST_YEAR_BASIS), 2)
+_SEED_FILE = os.path.join(os.path.dirname(__file__), "Sample Data Synthetic.xlsx")
 
 
 def seed_if_empty():
-    """Populate demo data when the database is empty.
+    """Populate demo data from the synthetic Excel file when the database is empty.
 
     Must be called after db.init_db().  The entire seed runs in a single
     transaction so a partial failure leaves the database unchanged.
@@ -21,95 +19,21 @@ def seed_if_empty():
         if existing_banks > 0:
             return False
 
-        banks = [
-            ("B001", "UBS"),
-            ("B002", "Credit Suisse"),
-            ("B003", "Zuercher Kantonalbank"),
-        ]
-        for key, name in banks:
-            db.upsert_bank(conn, key, name)
+        data = import_utils.parse_excel(_SEED_FILE)
 
-        today = date.today()
-
-        credit_lines = [
-            {
-                "bank_key": "B001",
-                "description": "Syndicated Facility",
-                "currency": "CHF",
-                "amount": 600_000_000,
-                "committed": "Yes",
-                "start_date": (today - timedelta(days=120)).isoformat(),
-                "end_date": (today + timedelta(days=330)).isoformat(),
-                "note": "Demo committed facility",
-            },
-            {
-                "bank_key": "B002",
-                "description": "EUR Money Market Line",
-                "currency": "EUR",
-                "amount": 450_000_000,
-                "committed": "Yes",
-                "start_date": (today - timedelta(days=90)).isoformat(),
-                "end_date": (today + timedelta(days=240)).isoformat(),
-                "note": "Demo EUR line",
-            },
-            {
-                "bank_key": "B003",
-                "description": "USD Revolver",
-                "currency": "USD",
-                "amount": 300_000_000,
-                "committed": "No",
-                "start_date": (today - timedelta(days=60)).isoformat(),
-                "end_date": (today + timedelta(days=300)).isoformat(),
-                "note": "Demo uncommitted line",
-            },
-        ]
+        for bank in data["banks"]["rows"]:
+            db.upsert_bank(conn, bank["bank_key"], bank["bank_name"])
 
         cl_ids = []
-        for payload in credit_lines:
-            cl_ids.append(db.create_credit_line(conn, payload))
+        for cl in data["credit_lines"]["rows"]:
+            cl_ids.append(db.create_credit_line(conn, cl))
 
-        advances = [
-            {
-                "bank": "UBS",
-                "credit_line_id": cl_ids[0],
-                "currency": "CHF",
-                "amount_original": 80_000_000,
-                "start_date": (today - timedelta(days=27)).isoformat(),
-                "end_date": (today + timedelta(days=4)).isoformat(),
-                "interest_amount": _interest(80_000_000, 31, 1.85),
-            },
-            {
-                "bank": "UBS",
-                "credit_line_id": cl_ids[0],
-                "currency": "CHF",
-                "amount_original": 55_000_000,
-                "start_date": (today - timedelta(days=15)).isoformat(),
-                "end_date": (today + timedelta(days=16)).isoformat(),
-                "interest_amount": _interest(55_000_000, 31, 1.65),
-            },
-            {
-                "bank": "Credit Suisse",
-                "credit_line_id": cl_ids[1],
-                "currency": "EUR",
-                "amount_original": 62_000_000,
-                "start_date": (today - timedelta(days=21)).isoformat(),
-                "end_date": (today + timedelta(days=6)).isoformat(),
-                "interest_amount": _interest(62_000_000, 27, 2.1),
-            },
-            {
-                "bank": "Zuercher Kantonalbank",
-                "credit_line_id": cl_ids[2],
-                "currency": "USD",
-                "amount_original": 45_000_000,
-                "start_date": (today - timedelta(days=12)).isoformat(),
-                "end_date": (today + timedelta(days=10)).isoformat(),
-                "interest_amount": _interest(45_000_000, 22, 2.35),
-            },
-        ]
-
-        for payload in advances:
-            payload = dict(payload)
-            payload["continuation_date"] = helpers.suggest_continuation_date(payload["end_date"])
+        for adv in data["advances"]["rows"]:
+            payload = dict(adv)
+            if not payload.get("continuation_date"):
+                payload["continuation_date"] = helpers.suggest_continuation_date(
+                    payload["end_date"]
+                )
             db.create_advance(conn, payload)
 
         conn.commit()

--- a/seed.py
+++ b/seed.py
@@ -1,10 +1,161 @@
 import os
+from copy import deepcopy
+from datetime import date, timedelta
 
 import db
 import helpers
 import import_utils
 
 _SEED_FILE = os.path.join(os.path.dirname(__file__), "Sample Data Synthetic.xlsx")
+
+
+def _safe_iso_add_days(value, delta_days):
+    if not value:
+        return value
+    try:
+        d = date.fromisoformat(value)
+    except (TypeError, ValueError):
+        return value
+    return (d + timedelta(days=delta_days)).isoformat()
+
+
+def _fallback_seed_data(today=None):
+    today = today or date.today()
+    return {
+        "banks": {
+            "rows": [
+                {"bank_key": "B001", "bank_name": "UBS"},
+                {"bank_key": "B002", "bank_name": "Credit Suisse"},
+                {"bank_key": "B003", "bank_name": "Zuercher Kantonalbank"},
+            ]
+        },
+        "credit_lines": {
+            "rows": [
+                {
+                    "id": "CL001",
+                    "bank_key": "B001",
+                    "description": "Syndicated Facility",
+                    "currency": "CHF",
+                    "amount": 600_000_000,
+                    "committed": "Yes",
+                    "start_date": (today - timedelta(days=120)).isoformat(),
+                    "end_date": (today + timedelta(days=330)).isoformat(),
+                    "note": "Demo committed facility",
+                },
+                {
+                    "id": "CL002",
+                    "bank_key": "B002",
+                    "description": "EUR Money Market Line",
+                    "currency": "EUR",
+                    "amount": 450_000_000,
+                    "committed": "Yes",
+                    "start_date": (today - timedelta(days=90)).isoformat(),
+                    "end_date": (today + timedelta(days=240)).isoformat(),
+                    "note": "Demo EUR line",
+                },
+                {
+                    "id": "CL003",
+                    "bank_key": "B003",
+                    "description": "USD Revolver",
+                    "currency": "USD",
+                    "amount": 300_000_000,
+                    "committed": "No",
+                    "start_date": (today - timedelta(days=60)).isoformat(),
+                    "end_date": (today + timedelta(days=300)).isoformat(),
+                    "note": "Demo uncommitted line",
+                },
+            ]
+        },
+        "advances": {
+            "rows": [
+                {
+                    "id": "FV0001",
+                    "bank": "UBS",
+                    "credit_line_id": "CL001",
+                    "start_date": (today - timedelta(days=27)).isoformat(),
+                    "end_date": (today + timedelta(days=4)).isoformat(),
+                    "continuation_date": helpers.suggest_continuation_date((today + timedelta(days=4)).isoformat()),
+                    "currency": "CHF",
+                    "amount_original": 80_000_000,
+                    "interest_amount": 127_555.56,
+                },
+                {
+                    "id": "FV0002",
+                    "bank": "UBS",
+                    "credit_line_id": "CL001",
+                    "start_date": (today - timedelta(days=15)).isoformat(),
+                    "end_date": (today + timedelta(days=16)).isoformat(),
+                    "continuation_date": helpers.suggest_continuation_date((today + timedelta(days=16)).isoformat()),
+                    "currency": "CHF",
+                    "amount_original": 55_000_000,
+                    "interest_amount": 78_145.83,
+                },
+                {
+                    "id": "FV0003",
+                    "bank": "Credit Suisse",
+                    "credit_line_id": "CL002",
+                    "start_date": (today - timedelta(days=21)).isoformat(),
+                    "end_date": (today + timedelta(days=6)).isoformat(),
+                    "continuation_date": helpers.suggest_continuation_date((today + timedelta(days=6)).isoformat()),
+                    "currency": "EUR",
+                    "amount_original": 62_000_000,
+                    "interest_amount": 97_650.00,
+                },
+                {
+                    "id": "FV0004",
+                    "bank": "Zuercher Kantonalbank",
+                    "credit_line_id": "CL003",
+                    "start_date": (today - timedelta(days=12)).isoformat(),
+                    "end_date": (today + timedelta(days=10)).isoformat(),
+                    "continuation_date": helpers.suggest_continuation_date((today + timedelta(days=10)).isoformat()),
+                    "currency": "USD",
+                    "amount_original": 45_000_000,
+                    "interest_amount": 64_625.00,
+                },
+            ]
+        },
+    }
+
+
+def _load_excel_seed_data():
+    if not os.path.exists(_SEED_FILE):
+        return None
+    return import_utils.parse_excel(_SEED_FILE)
+
+
+def _refresh_dates(seed_data, today=None):
+    """Shift stale seed dates forward so the demo always has active rows."""
+    today = today or date.today()
+    data = deepcopy(seed_data)
+
+    advances = data.get("advances", {}).get("rows", [])
+    end_dates = []
+    for adv in advances:
+        try:
+            end_dates.append(date.fromisoformat(adv["end_date"]))
+        except (KeyError, TypeError, ValueError):
+            continue
+
+    if not end_dates:
+        return data
+
+    target_latest_end = today + timedelta(days=21)
+    delta_days = (target_latest_end - max(end_dates)).days
+    if delta_days <= 0:
+        return data
+
+    for cl in data.get("credit_lines", {}).get("rows", []):
+        cl["start_date"] = _safe_iso_add_days(cl.get("start_date"), delta_days)
+        cl["end_date"] = _safe_iso_add_days(cl.get("end_date"), delta_days)
+
+    for adv in advances:
+        adv["start_date"] = _safe_iso_add_days(adv.get("start_date"), delta_days)
+        adv["end_date"] = _safe_iso_add_days(adv.get("end_date"), delta_days)
+        adv["continuation_date"] = _safe_iso_add_days(adv.get("continuation_date"), delta_days)
+        if not adv.get("continuation_date") and adv.get("end_date"):
+            adv["continuation_date"] = helpers.suggest_continuation_date(adv["end_date"])
+
+    return data
 
 
 def seed_if_empty():
@@ -19,22 +170,20 @@ def seed_if_empty():
         if existing_banks > 0:
             return False
 
-        data = import_utils.parse_excel(_SEED_FILE)
+        data = _load_excel_seed_data() or _fallback_seed_data()
+        data = _refresh_dates(data)
 
-        for bank in data["banks"]["rows"]:
-            db.upsert_bank(conn, bank["bank_key"], bank["bank_name"])
+        banks_result = db.bulk_insert_banks(conn, data["banks"]["rows"])
+        cl_result = db.bulk_insert_credit_lines(conn, data["credit_lines"]["rows"])
+        adv_result = db.bulk_insert_advances(conn, data["advances"]["rows"])
 
-        cl_ids = []
-        for cl in data["credit_lines"]["rows"]:
-            cl_ids.append(db.create_credit_line(conn, cl))
-
-        for adv in data["advances"]["rows"]:
-            payload = dict(adv)
-            if not payload.get("continuation_date"):
-                payload["continuation_date"] = helpers.suggest_continuation_date(
-                    payload["end_date"]
-                )
-            db.create_advance(conn, payload)
+        if cl_result["errors"] or adv_result["errors"]:
+            raise RuntimeError(
+                f"Seed insert failed: credit_lines errors={cl_result['errors']}, "
+                f"advances errors={adv_result['errors']}"
+            )
+        if banks_result["added"] == 0 and cl_result["added"] == 0 and adv_result["added"] == 0:
+            raise RuntimeError("Seed insert produced no records")
 
         conn.commit()
         return True

--- a/templates/advances.html
+++ b/templates/advances.html
@@ -7,11 +7,11 @@
 <div class="topbar">
   <h2>Fixed Advances</h2>
   <div class="topbar-actions">
-    <button class="btn-secondary" onclick="window.print()">
+    <button class="btn-secondary" id="print-btn">
       <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2"><path d="M3.5 5V1.5h7V5"/><rect x="1.5" y="5" width="11" height="5.5" rx="1"/><path d="M3.5 8.5h7v4h-7z"/></svg>
       Print
     </button>
-    <button class="btn-primary" onclick="openAdvForm()">
+    <button class="btn-primary" id="new-adv-btn">
       <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2"><line x1="7" y1="2" x2="7" y2="12"/><line x1="2" y1="7" x2="12" y2="7"/></svg>
       New Advance
     </button>
@@ -22,10 +22,10 @@
   <div class="section-header">
     <h3>All Advances ({{ advances|length }})</h3>
     <div class="filter-pills">
-      <span class="pill active" data-filter="all" onclick="filterAdvances('all', this)">All</span>
-      <span class="pill" data-filter="active" onclick="filterAdvances('active', this)">Active</span>
+      <span class="pill active" data-filter="all">All</span>
+      <span class="pill" data-filter="active">Active</span>
       {% for curr in currencies %}
-      <span class="pill" data-filter="{{ curr.code }}" onclick="filterAdvances('{{ curr.code }}', this)">{{ curr.code }}</span>
+      <span class="pill" data-filter="{{ curr.code }}">{{ curr.code }}</span>
       {% endfor %}
     </div>
   </div>
@@ -62,8 +62,8 @@
         <td><span class="badge {{ 'badge-active' if adv.active else 'badge-expired' }}">{{ 'Active' if adv.active else 'Expired' }}</span></td>
         <td>
           <div class="row-actions">
-            <button onclick="editAdv('{{ adv.id }}')" title="Edit">&#9998;</button>
-            <button class="delete" onclick="deleteAdv('{{ adv.id }}')" title="Delete">&times;</button>
+            <button class="action-edit" title="Edit">&#9998;</button>
+            <button class="delete action-delete" title="Delete">&times;</button>
           </div>
         </td>
       </tr>
@@ -85,7 +85,7 @@
   <div class="modal-box" style="width: 480px;">
     <h3>
       <span id="adv-view-title"></span>
-      <button class="panel-close" onclick="closeAdvView()">&times;</button>
+      <button class="panel-close" id="adv-view-close-btn">&times;</button>
     </h3>
     <div class="panel-view">
       <div class="detail-grid">
@@ -137,7 +137,7 @@
         </div>
       </div>
       <div class="form-actions">
-        <button type="button" class="btn-secondary" onclick="closeAdvView()">Close</button>
+        <button type="button" class="btn-secondary" id="adv-view-close-footer">Close</button>
         <button type="button" class="btn-primary" id="adv-view-edit-btn">
           <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.5 1.5l2 2L4 12H2v-2z"/></svg>
           Edit
@@ -152,15 +152,15 @@
   <div class="modal-box" style="width: 520px; max-height: 90vh; overflow-y: auto;">
     <h3>
       <span id="adv-panel-title">New Fixed Advance</span>
-      <button class="panel-close" onclick="closeAdvForm()">&times;</button>
+      <button class="panel-close" id="adv-form-close-btn">&times;</button>
     </h3>
-    <form id="adv-form" onsubmit="saveAdv(event)">
+    <form id="adv-form">
       <input type="hidden" id="adv-edit-id" value="" />
 
       <div class="form-row">
         <div class="form-group">
           <label>Bank</label>
-          <select id="adv-bank" required onchange="syncCLFromBank()">
+          <select id="adv-bank" required>
             <option value="">Select bank...</option>
             {% for bank in banks %}
             <option value="{{ bank.bank_name }}">{{ bank.bank_name }}</option>
@@ -169,7 +169,7 @@
         </div>
         <div class="form-group">
           <label>Credit Line</label>
-          <select id="adv-cl" required onchange="syncBankFromCL(); dismissClWarning()">
+          <select id="adv-cl" required>
             <option value="">Select...</option>
             {% for cl in lines %}
             <option value="{{ cl.id }}" data-bank="{{ cl.bank_name }}">{{ cl.id }} — {{ cl.description or cl.bank_name }}</option>
@@ -186,7 +186,7 @@
             <option value="{{ curr.code }}">{{ curr.code }}</option>
             {% endfor %}
           </select>
-          <button type="button" class="btn-add-currency" onclick="openCurrencyModal()" title="Add currency">+</button>
+          <button type="button" class="btn-add-currency" id="adv-add-currency-btn" title="Add currency">+</button>
         </div>
       </div>
 
@@ -197,7 +197,7 @@
         </div>
         <div class="form-group">
           <label>End Date</label>
-          <input type="date" id="adv-end" required onchange="suggestContinuation()" />
+          <input type="date" id="adv-end" required />
         </div>
       </div>
 
@@ -213,11 +213,11 @@
       <div class="form-row">
         <div class="form-group">
           <label>Amount</label>
-          <input type="text" id="adv-amount" required placeholder="e.g. 50,000,000" oninput="formatAmountField(this); updateCalcPreview(); dismissClWarning()" inputmode="numeric" />
+          <input type="text" id="adv-amount" required placeholder="e.g. 50,000,000" inputmode="numeric" />
         </div>
         <div class="form-group">
           <label>Interest Amount</label>
-          <input type="text" id="adv-interest" required placeholder="e.g. 196,527.78" oninput="formatAmountField(this, true); updateCalcPreview()" inputmode="decimal" />
+          <input type="text" id="adv-interest" required placeholder="e.g. 196,527.78" inputmode="decimal" />
         </div>
       </div>
 
@@ -238,7 +238,7 @@
       </div>
 
       <div class="form-actions">
-        <button type="button" class="btn-secondary" onclick="closeAdvForm()">Cancel</button>
+        <button type="button" class="btn-secondary" id="adv-form-cancel-btn">Cancel</button>
         <button type="submit" class="btn-primary">
           <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2"><polyline points="2 7 5.5 10.5 12 4"/></svg>
           Save Advance
@@ -251,7 +251,7 @@
 
 
 {% block scripts %}
-<script>
+<script nonce="{{ csp_nonce }}">
 const parseNum = window.TDNumber.parseLocaleNumber;
 
 function formatAmountField(el, allowDecimals) {
@@ -372,11 +372,13 @@ document.getElementById('adv-view-edit-btn').addEventListener('click', function(
   }
 });
 
-// Row click → open view mode (skip clicks on action buttons)
+// Row click → open view mode; action button delegation for edit/delete
 document.getElementById('advances-table').addEventListener('click', function(e) {
-  if (e.target.closest('.row-actions')) return;
   const row = e.target.closest('tr[data-id]');
-  if (row) viewAdv(row.dataset.id);
+  if (!row) return;
+  if (e.target.closest('.action-edit')) { editAdv(row.dataset.id); return; }
+  if (e.target.closest('.action-delete')) { deleteAdv(row.dataset.id); return; }
+  if (!e.target.closest('.row-actions')) viewAdv(row.dataset.id);
 });
 
 let clWarningAcknowledged = false;
@@ -546,5 +548,29 @@ function filterAdvances(filter, pill) {
     }
   });
 }
+
+// Bind event handlers
+document.getElementById('print-btn').addEventListener('click', function() { window.print(); });
+document.getElementById('new-adv-btn').addEventListener('click', openAdvForm);
+document.querySelectorAll('.filter-pills .pill[data-filter]').forEach(function(pill) {
+  pill.addEventListener('click', function() { filterAdvances(pill.dataset.filter, pill); });
+});
+document.getElementById('adv-view-close-btn').addEventListener('click', closeAdvView);
+document.getElementById('adv-view-close-footer').addEventListener('click', closeAdvView);
+document.getElementById('adv-form-close-btn').addEventListener('click', closeAdvForm);
+document.getElementById('adv-form-cancel-btn').addEventListener('click', closeAdvForm);
+document.getElementById('adv-form').addEventListener('submit', saveAdv);
+document.getElementById('adv-bank').addEventListener('change', syncCLFromBank);
+document.getElementById('adv-cl').addEventListener('change', function() {
+  syncBankFromCL(); dismissClWarning();
+});
+document.getElementById('adv-add-currency-btn').addEventListener('click', openCurrencyModal);
+document.getElementById('adv-end').addEventListener('change', suggestContinuation);
+document.getElementById('adv-amount').addEventListener('input', function() {
+  formatAmountField(this); updateCalcPreview(); dismissClWarning();
+});
+document.getElementById('adv-interest').addEventListener('input', function() {
+  formatAmountField(this, true); updateCalcPreview();
+});
 </script>
 {% endblock %}

--- a/templates/banks.html
+++ b/templates/banks.html
@@ -7,11 +7,11 @@
 <div class="topbar">
   <h2>Banks</h2>
   <div class="topbar-actions">
-    <button class="btn-secondary" onclick="window.print()">
+    <button class="btn-secondary" id="print-btn">
       <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2"><path d="M3.5 5V1.5h7V5"/><rect x="1.5" y="5" width="11" height="5.5" rx="1"/><path d="M3.5 8.5h7v4h-7z"/></svg>
       Print
     </button>
-    <button class="btn-primary" onclick="openBankForm()">
+    <button class="btn-primary" id="new-bank-btn">
       <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2"><line x1="7" y1="2" x2="7" y2="12"/><line x1="2" y1="7" x2="12" y2="7"/></svg>
       Add Bank
     </button>
@@ -34,8 +34,8 @@
         <td>{{ bank.bank_name }}</td>
         <td>
           <div class="row-actions">
-            <button onclick="editBank('{{ bank.bank_key }}', '{{ bank.bank_name }}')" title="Edit">&#9998;</button>
-            <button class="delete" onclick="deleteBank('{{ bank.bank_key }}')" title="Delete">&times;</button>
+            <button class="action-edit" title="Edit">&#9998;</button>
+            <button class="delete action-delete" title="Delete">&times;</button>
           </div>
         </td>
       </tr>
@@ -57,7 +57,7 @@
   <div class="modal-box" style="width: 400px;">
     <h3>
       <span id="bank-view-title"></span>
-      <button class="panel-close" onclick="closeBankView()">&times;</button>
+      <button class="panel-close" id="bank-view-close-btn">&times;</button>
     </h3>
     <div class="panel-view">
       <div class="detail-grid">
@@ -71,7 +71,7 @@
         </div>
       </div>
       <div class="form-actions">
-        <button type="button" class="btn-secondary" onclick="closeBankView()">Close</button>
+        <button type="button" class="btn-secondary" id="bank-view-close-footer">Close</button>
         <button type="button" class="btn-primary" id="bank-view-edit-btn">
           <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.5 1.5l2 2L4 12H2v-2z"/></svg>
           Edit
@@ -86,9 +86,9 @@
   <div class="modal-box" style="width: 400px;">
     <h3>
       <span id="bank-form-title">Add Bank</span>
-      <button class="panel-close" onclick="closeBankForm()">&times;</button>
+      <button class="panel-close" id="bank-form-close-btn">&times;</button>
     </h3>
-    <form id="bank-form" onsubmit="saveBank(event)">
+    <form id="bank-form">
       <div class="form-group">
         <label>Bank Key</label>
         <input type="text" id="bank-key" required placeholder="e.g. B001" />
@@ -98,7 +98,7 @@
         <input type="text" id="bank-name" required placeholder="e.g. UBS" />
       </div>
       <div class="form-actions">
-        <button type="button" class="btn-secondary" onclick="closeBankForm()">Cancel</button>
+        <button type="button" class="btn-secondary" id="bank-form-cancel-btn">Cancel</button>
         <button type="submit" class="btn-primary">
           <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2"><polyline points="2 7 5.5 10.5 12 4"/></svg>
           Save
@@ -110,7 +110,7 @@
 {% endblock %}
 
 {% block scripts %}
-<script>
+<script nonce="{{ csp_nonce }}">
 let currentViewBankKey = null;
 
 function openBankForm(key, name) {
@@ -151,15 +151,15 @@ document.getElementById('bank-view-edit-btn').addEventListener('click', function
   }
 });
 
-// Row click → open view mode (skip clicks on action buttons)
+// Row click → open view mode; action button delegation for edit/delete
 document.getElementById('banks-table').addEventListener('click', function(e) {
-  if (e.target.closest('.row-actions')) return;
   const row = e.target.closest('tr[data-key]');
-  if (row) {
-    const key = row.dataset.key;
-    const name = row.children[1].textContent;
-    viewBank(key, name);
-  }
+  if (!row) return;
+  const key = row.dataset.key;
+  const name = row.children[1].textContent;
+  if (e.target.closest('.action-edit')) { editBank(key, name); return; }
+  if (e.target.closest('.action-delete')) { deleteBank(key); return; }
+  if (!e.target.closest('.row-actions')) viewBank(key, name);
 });
 
 async function saveBank(e) {
@@ -181,5 +181,14 @@ async function deleteBank(key) {
   const res = await fetch('/banks/' + key, { method: 'DELETE' });
   if (res.ok) location.reload();
 }
+
+// Bind event handlers
+document.getElementById('print-btn').addEventListener('click', function() { window.print(); });
+document.getElementById('new-bank-btn').addEventListener('click', function() { openBankForm(); });
+document.getElementById('bank-view-close-btn').addEventListener('click', closeBankView);
+document.getElementById('bank-view-close-footer').addEventListener('click', closeBankView);
+document.getElementById('bank-form-close-btn').addEventListener('click', closeBankForm);
+document.getElementById('bank-form-cancel-btn').addEventListener('click', closeBankForm);
+document.getElementById('bank-form').addEventListener('submit', saveBank);
 </script>
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -50,7 +50,7 @@
       <svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 1v9m0 0L5 7m3 3l3-3M2 12v2h12v-2"/></svg>
       Import
     </a>
-    <a href="#" class="nav-item" onclick="openSettingsModal(); return false;">
+    <a href="#" class="nav-item" id="nav-settings">
       <svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 10a2 2 0 100-4 2 2 0 000 4zm6.32-1.906l-1.066-.616a5.21 5.21 0 000-1.956l1.066-.616a.5.5 0 00.183-.683l-1-1.732a.5.5 0 00-.683-.183l-1.066.616a5.163 5.163 0 00-1.694-.978V1.5a.5.5 0 00-.5-.5h-2a.5.5 0 00-.5.5v1.232a5.163 5.163 0 00-1.694.978L4.3 3.094a.5.5 0 00-.683.183l-1 1.732a.5.5 0 00.183.683l1.066.616a5.21 5.21 0 000 1.956l-1.066.616a.5.5 0 00-.183.683l1 1.732a.5.5 0 00.683.183l1.066-.616c.502.42 1.075.748 1.694.978V14.5a.5.5 0 00.5.5h2a.5.5 0 00.5-.5v-1.232a5.163 5.163 0 001.694-.978l1.066.616a.5.5 0 00.683-.183l1-1.732a.5.5 0 00-.183-.683z"/></svg>
       Settings
     </a>
@@ -75,7 +75,7 @@
     {% if demo_mode %}
     <div class="demo-banner" id="demo-banner" role="status" aria-live="polite">
       <span>This is a live read-only demo - data resets periodically.</span>
-      <button type="button" class="demo-banner-close" onclick="dismissDemoBanner()" aria-label="Dismiss demo banner">&times;</button>
+      <button type="button" class="demo-banner-close" id="demo-banner-close" aria-label="Dismiss demo banner">&times;</button>
     </div>
     {% endif %}
     {% block content %}{% endblock %}
@@ -98,9 +98,9 @@
     <div class="modal-box">
       <h3>
         Add Currency
-        <button class="panel-close" onclick="closeCurrencyModal()">&times;</button>
+        <button class="panel-close" id="currency-close-btn">&times;</button>
       </h3>
-      <form id="currency-form" onsubmit="saveCurrency(event)">
+      <form id="currency-form">
         <div class="form-group">
           <label>Currency Code (3 letters)</label>
           <input type="text" id="currency-code" maxlength="3" pattern="[A-Za-z]{3}" required
@@ -108,7 +108,7 @@
         </div>
         <div class="currency-msg" id="currency-msg" style="display:none"></div>
         <div class="form-actions">
-          <button type="button" class="btn-secondary" onclick="closeCurrencyModal()">Cancel</button>
+          <button type="button" class="btn-secondary" id="currency-cancel-btn">Cancel</button>
           <button type="submit" class="btn-primary" id="currency-submit-btn">
             <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2"><polyline points="2 7 5.5 10.5 12 4"/></svg>
             Add
@@ -123,9 +123,9 @@
     <div class="modal-box" style="width: 480px;">
       <h3>
         Settings
-        <button class="panel-close" onclick="closeSettingsModal()">&times;</button>
+        <button class="panel-close" id="settings-close-btn">&times;</button>
       </h3>
-      <form id="settings-form" onsubmit="saveSettings(event)">
+      <form id="settings-form">
         <div class="form-group">
           <label>Display Unit</label>
           <select id="settings-display-unit">
@@ -150,7 +150,6 @@
                    placeholder="/path/to/export/folder" style="flex:1;"
                    {% if demo_mode %}readonly title="Export path configuration is disabled in demo mode"{% endif %} />
             <button type="button" class="btn-secondary" id="browse-btn"
-                    onclick="openFolderBrowser()"
                     {% if demo_mode %}disabled title="Export path configuration is disabled in demo mode"{% endif %}>Browse</button>
           </div>
           {% if demo_mode %}
@@ -161,15 +160,14 @@
             <div class="folder-list" id="folder-list"></div>
             <div class="folder-actions">
               <span class="folder-status" id="folder-status"></span>
-              <button type="button" class="btn-primary btn-sm" id="folder-select-btn"
-                      onclick="selectFolder()">Select this folder</button>
+              <button type="button" class="btn-primary btn-sm" id="folder-select-btn">Select this folder</button>
             </div>
           </div>
           <div class="form-hint" style="color: var(--text-light);">Directory where .xlsx exports are saved</div>
         </div>
         <div class="currency-msg" id="settings-msg" style="display:none"></div>
         <div class="form-actions">
-          <button type="button" class="btn-secondary" onclick="closeSettingsModal()">Cancel</button>
+          <button type="button" class="btn-secondary" id="settings-cancel-btn">Cancel</button>
           <button type="submit" class="btn-primary" id="settings-submit-btn">
             <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2"><polyline points="2 7 5.5 10.5 12 4"/></svg>
             Save
@@ -179,8 +177,8 @@
     </div>
   </div>
 
-  <script src="{{ url_for('static', filename='app.js') }}"></script>
-  <script>
+  <script nonce="{{ csp_nonce }}" src="{{ url_for('static', filename='app.js') }}"></script>
+  <script nonce="{{ csp_nonce }}">
   window.TENORDASH_DEMO_MODE = {{ "true" if demo_mode else "false" }};
 
   function dismissDemoBanner() {
@@ -275,6 +273,21 @@
   document.addEventListener('keydown', function(e) {
     if (e.key === 'Escape') { closeCurrencyModal(); closeSettingsModal(); }
   });
+
+  // Bind base-template event handlers (replaces inline onclick/onsubmit)
+  document.getElementById('nav-settings').addEventListener('click', function(e) {
+    e.preventDefault(); openSettingsModal();
+  });
+  var demoBannerClose = document.getElementById('demo-banner-close');
+  if (demoBannerClose) demoBannerClose.addEventListener('click', dismissDemoBanner);
+  document.getElementById('currency-close-btn').addEventListener('click', closeCurrencyModal);
+  document.getElementById('currency-cancel-btn').addEventListener('click', closeCurrencyModal);
+  document.getElementById('currency-form').addEventListener('submit', saveCurrency);
+  document.getElementById('settings-close-btn').addEventListener('click', closeSettingsModal);
+  document.getElementById('settings-cancel-btn').addEventListener('click', closeSettingsModal);
+  document.getElementById('settings-form').addEventListener('submit', saveSettings);
+  document.getElementById('browse-btn').addEventListener('click', openFolderBrowser);
+  document.getElementById('folder-select-btn').addEventListener('click', selectFolder);
   </script>
   {% block scripts %}{% endblock %}
 </body>

--- a/templates/credit_lines.html
+++ b/templates/credit_lines.html
@@ -7,11 +7,11 @@
 <div class="topbar">
   <h2>Credit Lines</h2>
   <div class="topbar-actions">
-    <button class="btn-secondary" onclick="window.print()">
+    <button class="btn-secondary" id="print-btn">
       <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2"><path d="M3.5 5V1.5h7V5"/><rect x="1.5" y="5" width="11" height="5.5" rx="1"/><path d="M3.5 8.5h7v4h-7z"/></svg>
       Print
     </button>
-    <button class="btn-primary" onclick="openCLForm()">
+    <button class="btn-primary" id="new-cl-btn">
       <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2"><line x1="7" y1="2" x2="7" y2="12"/><line x1="2" y1="7" x2="12" y2="7"/></svg>
       New Credit Line
     </button>
@@ -22,9 +22,9 @@
   <div class="section-header">
     <h3>Credit Lines ({{ lines|selectattr('archived', 'equalto', 0)|list|length }})</h3>
     <div class="filter-pills">
-      <span class="pill active" data-filter="active" onclick="filterCLs('active', this)">Active</span>
-      <span class="pill" data-filter="archived" onclick="filterCLs('archived', this)">Archived</span>
-      <span class="pill" data-filter="all" onclick="filterCLs('all', this)">All</span>
+      <span class="pill active" data-filter="active">Active</span>
+      <span class="pill" data-filter="archived">Archived</span>
+      <span class="pill" data-filter="all">All</span>
     </div>
   </div>
   <table class="data-table" id="cl-table">
@@ -63,10 +63,10 @@
         <td>
           <div class="row-actions">
             {% if cl.archived %}
-            <button onclick="restoreCL('{{ cl.id }}')" title="Restore">&#8634;</button>
+            <button class="action-restore" title="Restore">&#8634;</button>
             {% else %}
-            <button onclick="editCL('{{ cl.id }}')" title="Edit">&#9998;</button>
-            <button class="delete" onclick="archiveCL('{{ cl.id }}')" title="Archive">&#128451;</button>
+            <button class="action-edit" title="Edit">&#9998;</button>
+            <button class="delete action-archive" title="Archive">&#128451;</button>
             {% endif %}
           </div>
         </td>
@@ -89,7 +89,7 @@
   <div class="modal-box" style="width: 480px;">
     <h3>
       <span id="cl-view-title"></span>
-      <button class="panel-close" onclick="closeCLView()">&times;</button>
+      <button class="panel-close" id="cl-view-close-btn">&times;</button>
     </h3>
     <div class="panel-view">
       <div class="detail-grid">
@@ -131,7 +131,7 @@
         </div>
       </div>
       <div class="form-actions">
-        <button type="button" class="btn-secondary" onclick="closeCLView()">Close</button>
+        <button type="button" class="btn-secondary" id="cl-view-close-footer">Close</button>
         <button type="button" class="btn-primary" id="cl-view-edit-btn">
           <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.5 1.5l2 2L4 12H2v-2z"/></svg>
           Edit
@@ -146,9 +146,9 @@
   <div class="modal-box" style="width: 520px; max-height: 90vh; overflow-y: auto;">
     <h3>
       <span id="cl-panel-title">New Credit Line</span>
-      <button class="panel-close" onclick="closeCLForm()">&times;</button>
+      <button class="panel-close" id="cl-form-close-btn">&times;</button>
     </h3>
-    <form id="cl-form" onsubmit="saveCL(event)">
+    <form id="cl-form">
       <input type="hidden" id="cl-edit-id" value="" />
       <div class="form-group">
         <label>Bank</label>
@@ -172,12 +172,12 @@
               <option value="{{ curr.code }}">{{ curr.code }}</option>
               {% endfor %}
             </select>
-            <button type="button" class="btn-add-currency" onclick="openCurrencyModal()" title="Add currency">+</button>
+            <button type="button" class="btn-add-currency" id="cl-add-currency-btn" title="Add currency">+</button>
           </div>
         </div>
         <div class="form-group">
           <label>Amount</label>
-          <input type="text" id="cl-amount" required placeholder="e.g. 510,000,000" oninput="formatCLAmount(this)" inputmode="numeric" />
+          <input type="text" id="cl-amount" required placeholder="e.g. 510,000,000" inputmode="numeric" />
         </div>
       </div>
       <div class="form-group">
@@ -202,7 +202,7 @@
         <textarea id="cl-note" placeholder="Optional notes..."></textarea>
       </div>
       <div class="form-actions">
-        <button type="button" class="btn-secondary" onclick="closeCLForm()">Cancel</button>
+        <button type="button" class="btn-secondary" id="cl-form-cancel-btn">Cancel</button>
         <button type="submit" class="btn-primary">
           <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2"><polyline points="2 7 5.5 10.5 12 4"/></svg>
           Save
@@ -214,7 +214,7 @@
 {% endblock %}
 
 {% block scripts %}
-<script>
+<script nonce="{{ csp_nonce }}">
 const parseNum = window.TDNumber.parseLocaleNumber;
 
 function formatCLAmount(el) {
@@ -289,11 +289,14 @@ document.getElementById('cl-view-edit-btn').addEventListener('click', function()
   }
 });
 
-// Row click → open view mode (skip clicks on action buttons)
+// Row click → open view mode; action button delegation
 document.getElementById('cl-table').addEventListener('click', function(e) {
-  if (e.target.closest('.row-actions')) return;
   const row = e.target.closest('tr[data-id]');
-  if (row) viewCL(row.dataset.id);
+  if (!row) return;
+  if (e.target.closest('.action-edit')) { editCL(row.dataset.id); return; }
+  if (e.target.closest('.action-archive')) { archiveCL(row.dataset.id); return; }
+  if (e.target.closest('.action-restore')) { restoreCL(row.dataset.id); return; }
+  if (!e.target.closest('.row-actions')) viewCL(row.dataset.id);
 });
 
 async function saveCL(e) {
@@ -353,5 +356,19 @@ function filterCLs(filter, pill) {
   const label = filter === 'all' ? 'All Credit Lines' : filter === 'archived' ? 'Archived Credit Lines' : 'Credit Lines';
   h3.textContent = label + ' (' + visible + ')';
 }
+
+// Bind event handlers
+document.getElementById('print-btn').addEventListener('click', function() { window.print(); });
+document.getElementById('new-cl-btn').addEventListener('click', openCLForm);
+document.querySelectorAll('.filter-pills .pill[data-filter]').forEach(function(pill) {
+  pill.addEventListener('click', function() { filterCLs(pill.dataset.filter, pill); });
+});
+document.getElementById('cl-view-close-btn').addEventListener('click', closeCLView);
+document.getElementById('cl-view-close-footer').addEventListener('click', closeCLView);
+document.getElementById('cl-form-close-btn').addEventListener('click', closeCLForm);
+document.getElementById('cl-form-cancel-btn').addEventListener('click', closeCLForm);
+document.getElementById('cl-form').addEventListener('submit', saveCL);
+document.getElementById('cl-add-currency-btn').addEventListener('click', openCurrencyModal);
+document.getElementById('cl-amount').addEventListener('input', function() { formatCLAmount(this); });
 </script>
 {% endblock %}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -8,7 +8,7 @@
 <div class="topbar">
   <h2>Dashboard</h2>
   <div class="topbar-actions">
-    <button class="btn-secondary" onclick="window.print()">
+    <button class="btn-secondary" id="print-btn">
       <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2"><path d="M3.5 5V1.5h7V5"/><rect x="1.5" y="5" width="11" height="5.5" rx="1"/><path d="M3.5 8.5h7v4h-7z"/></svg>
       Print
     </button>
@@ -42,9 +42,9 @@
       <div class="section-header">
         <h3>Active Instruments ({{ active|length }})</h3>
         <div class="filter-pills">
-          <span class="pill active" onclick="filterDash('all', this)">All</span>
+          <span class="pill active" data-filter="all">All</span>
           {% for curr in currencies %}
-          <span class="pill" onclick="filterDash('{{ curr.code }}', this)">{{ curr.code }}</span>
+          <span class="pill" data-filter="{{ curr.code }}">{{ curr.code }}</span>
           {% endfor %}
         </div>
       </div>
@@ -106,8 +106,8 @@
         Upcoming Continuations
       </div>
       <div class="continuation-view-switch">
-        <button class="pill active" type="button" data-view="list" onclick="switchContinuationView('list', this)">List</button>
-        <button class="pill" type="button" data-view="calendar" onclick="switchContinuationView('calendar', this)">Calendar</button>
+        <button class="pill active" type="button" data-view="list">List</button>
+        <button class="pill" type="button" data-view="calendar">Calendar</button>
       </div>
 
       <!-- Timeline: Date-left list card -->
@@ -134,11 +134,11 @@
         {% if continuation_calendar is defined %}
         <div class="mini-calendar">
           <div class="mini-cal-header">
-            <button class="cal-nav-btn" type="button" onclick="navigateCalendar(-1)" aria-label="Previous month">&lsaquo;</button>
+            <button class="cal-nav-btn" type="button" id="cal-prev-btn" aria-label="Previous month">&lsaquo;</button>
             <strong id="cal-month-label"
                     data-year="{{ continuation_calendar.year }}"
                     data-month="{{ continuation_calendar.month }}">{{ continuation_calendar.month_label }}</strong>
-            <button class="cal-nav-btn" type="button" onclick="navigateCalendar(1)" aria-label="Next month">&rsaquo;</button>
+            <button class="cal-nav-btn" type="button" id="cal-next-btn" aria-label="Next month">&rsaquo;</button>
           </div>
           <div class="mini-cal-grid mini-cal-weekdays">
             <div>Mo</div><div>Tu</div><div>We</div><div>Th</div><div>Fr</div><div>Sa</div><div>Su</div>
@@ -212,7 +212,7 @@
   <div class="modal-box" style="width: 480px;">
     <h3>
       <span id="dash-panel-title"></span>
-      <button class="panel-close" onclick="closeDashPanel()">&times;</button>
+      <button class="panel-close" id="dash-panel-close">&times;</button>
     </h3>
     <div class="panel-view">
       <div class="detail-grid">
@@ -264,7 +264,7 @@
         </div>
       </div>
       <div class="form-actions">
-        <button type="button" class="btn-secondary" onclick="closeDashPanel()">Close</button>
+        <button type="button" class="btn-secondary" id="dash-panel-close-btn">Close</button>
         <a href="#" class="btn-primary" id="dash-view-edit-link">
           <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.5 1.5l2 2L4 12H2v-2z"/></svg>
           Edit
@@ -276,7 +276,7 @@
 {% endblock %}
 
 {% block scripts %}
-<script>
+<script nonce="{{ csp_nonce }}">
 // ── Column sorting ──
 const numericSortKeys = new Set(['amount', 'rate']);
 
@@ -441,5 +441,20 @@ async function navigateCalendar(delta) {
     }).join('');
   }
 }
+
+// Bind event handlers
+document.getElementById('print-btn').addEventListener('click', function() { window.print(); });
+document.querySelectorAll('.filter-pills .pill[data-filter]').forEach(function(pill) {
+  pill.addEventListener('click', function() { filterDash(pill.dataset.filter, pill); });
+});
+document.querySelectorAll('.continuation-view-switch .pill[data-view]').forEach(function(btn) {
+  btn.addEventListener('click', function() { switchContinuationView(btn.dataset.view, btn); });
+});
+var calPrev = document.getElementById('cal-prev-btn');
+var calNext = document.getElementById('cal-next-btn');
+if (calPrev) calPrev.addEventListener('click', function() { navigateCalendar(-1); });
+if (calNext) calNext.addEventListener('click', function() { navigateCalendar(1); });
+document.getElementById('dash-panel-close').addEventListener('click', closeDashPanel);
+document.getElementById('dash-panel-close-btn').addEventListener('click', closeDashPanel);
 </script>
 {% endblock %}

--- a/templates/import.html
+++ b/templates/import.html
@@ -81,11 +81,11 @@
 
   <!-- Confirm / Cancel -->
   <div style="display: flex; gap: 12px; margin-top: 20px;">
-    <button class="btn-primary" id="confirm-btn" onclick="executeImport()">
+    <button class="btn-primary" id="confirm-btn">
       <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2"><polyline points="2 7 5.5 10.5 12 4"/></svg>
       Confirm Import
     </button>
-    <button class="btn-secondary" onclick="resetImport()">Cancel</button>
+    <button class="btn-secondary" id="import-cancel-btn">Cancel</button>
   </div>
 </div>
 
@@ -106,7 +106,7 @@
 {% endblock %}
 
 {% block scripts %}
-<script>
+<script nonce="{{ csp_nonce }}">
 let currentFile = null;
 
 document.getElementById('import-upload-form').addEventListener('submit', async function(e) {
@@ -261,5 +261,9 @@ function resetImport() {
   document.getElementById('import-file').value = '';
   currentFile = null;
 }
+
+// Bind event handlers
+document.getElementById('confirm-btn').addEventListener('click', executeImport);
+document.getElementById('import-cancel-btn').addEventListener('click', resetImport);
 </script>
 {% endblock %}

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -91,6 +91,23 @@ class ApiContractTests(unittest.TestCase):
         res = self.client.get("/api/check-cl-capacity?cl_id=CL001&amount=not-a-number")
         self.assertEqual(res.status_code, 400)
 
+    def test_security_headers_present(self):
+        res = self.client.get("/")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.headers.get("X-Content-Type-Options"), "nosniff")
+        self.assertEqual(res.headers.get("X-Frame-Options"), "DENY")
+        self.assertEqual(res.headers.get("Referrer-Policy"), "strict-origin-when-cross-origin")
+        self.assertIn("default-src 'self'", res.headers.get("Content-Security-Policy", ""))
+        self.assertIsNone(res.headers.get("Strict-Transport-Security"))
+
+    def test_hsts_present_for_https_forwarded_proto(self):
+        res = self.client.get("/", headers={"X-Forwarded-Proto": "https"})
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(
+            res.headers.get("Strict-Transport-Security"),
+            "max-age=31536000; includeSubDomains",
+        )
+
     def test_currency_api_invalid_and_duplicate(self):
         res = self.client.post("/api/currencies", json={"code": "US"})
         self.assertEqual(res.status_code, 400)

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -97,7 +97,10 @@ class ApiContractTests(unittest.TestCase):
         self.assertEqual(res.headers.get("X-Content-Type-Options"), "nosniff")
         self.assertEqual(res.headers.get("X-Frame-Options"), "DENY")
         self.assertEqual(res.headers.get("Referrer-Policy"), "strict-origin-when-cross-origin")
-        self.assertIn("default-src 'self'", res.headers.get("Content-Security-Policy", ""))
+        csp = res.headers.get("Content-Security-Policy", "")
+        self.assertIn("default-src 'self'", csp)
+        self.assertRegex(csp, r"'nonce-[A-Za-z0-9_-]+'")
+        self.assertNotIn("'unsafe-inline'", csp.split("script-src")[1].split(";")[0])
         self.assertIsNone(res.headers.get("Strict-Transport-Security"))
 
     def test_hsts_present_for_https_forwarded_proto(self):

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -1,0 +1,89 @@
+import os
+import tempfile
+import unittest
+from datetime import date
+from unittest import mock
+
+import db
+import seed
+
+
+class SeedTests(unittest.TestCase):
+    def setUp(self):
+        tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmpdir.cleanup)
+        db_path = os.path.join(tmpdir.name, "test_seed.db")
+
+        orig_db_path = db.DB_PATH
+        self.addCleanup(setattr, db, "DB_PATH", orig_db_path)
+        db.DB_PATH = db_path
+        db.init_db()
+
+    def test_seed_falls_back_when_excel_missing(self):
+        with mock.patch("seed._load_excel_seed_data", return_value=None):
+            seeded = seed.seed_if_empty()
+
+        self.assertTrue(seeded)
+        with db.get_db() as conn:
+            bank_count = conn.execute("SELECT COUNT(*) FROM banks").fetchone()[0]
+            cl_count = conn.execute("SELECT COUNT(*) FROM credit_lines").fetchone()[0]
+            adv_count = conn.execute("SELECT COUNT(*) FROM fixed_advances").fetchone()[0]
+            active_count = conn.execute(
+                "SELECT COUNT(*) FROM fixed_advances WHERE start_date <= date('now') AND end_date > date('now')"
+            ).fetchone()[0]
+
+        self.assertGreater(bank_count, 0)
+        self.assertGreater(cl_count, 0)
+        self.assertGreater(adv_count, 0)
+        self.assertGreater(active_count, 0)
+
+        seeded_again = seed.seed_if_empty()
+        self.assertFalse(seeded_again)
+
+    def test_seed_refreshes_stale_excel_dates(self):
+        stale_data = {
+            "banks": {"rows": [{"bank_key": "B900", "bank_name": "Bank 900"}]},
+            "credit_lines": {
+                "rows": [{
+                    "id": "CL900",
+                    "bank_key": "B900",
+                    "description": "Stale CL",
+                    "currency": "CHF",
+                    "amount": 10_000_000,
+                    "committed": "Yes",
+                    "start_date": "2025-01-01",
+                    "end_date": "2025-03-01",
+                    "note": None,
+                }]
+            },
+            "advances": {
+                "rows": [{
+                    "id": "FV9001",
+                    "bank": "Bank 900",
+                    "credit_line_id": "CL900",
+                    "start_date": "2025-01-10",
+                    "end_date": "2025-02-10",
+                    "continuation_date": "2025-02-05",
+                    "currency": "CHF",
+                    "amount_original": 1_000_000,
+                    "interest_amount": 1_000.0,
+                }]
+            },
+        }
+
+        with mock.patch("seed._load_excel_seed_data", return_value=stale_data):
+            seeded = seed.seed_if_empty()
+
+        self.assertTrue(seeded)
+        with db.get_db() as conn:
+            row = conn.execute(
+                "SELECT start_date, end_date, continuation_date FROM fixed_advances WHERE id = ?",
+                ("FV9001",),
+            ).fetchone()
+            self.assertIsNotNone(row)
+            end_date = date.fromisoformat(row["end_date"])
+            self.assertGreater(end_date, date.today())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add HSTS (`max-age=31536000; includeSubDomains`) on HTTPS requests and Content-Security-Policy response headers
- Replace `'unsafe-inline'` in CSP script-src with per-request nonces — all 58 inline event handlers across 6 templates converted to `addEventListener` bindings
- Rewrite `seed.py` to load demo data from `Sample Data Synthetic.xlsx` (4 banks, 4 credit lines, 195 advances) instead of hardcoded values
- Delete unused `Sample Data Fixed Advances.xlsm` (was untracked/gitignored, no code references)

## Test plan
- [x] `python -m pytest -q` → 98 passed
- [x] Smoke test: all 5 pages render with nonce in CSP, zero inline handlers in HTML
- [x] CSP contract test verifies nonce regex and absence of `unsafe-inline` in script-src
- [x] HSTS test verifies header only sent when `X-Forwarded-Proto: https`
- [ ] Manual browser test: verify all modals, forms, filters, and buttons still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)